### PR TITLE
Enable CommonMark CJK friendly emphasis extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'propshaft', '~> 1.1.0'
 gem 'rack', '>= 3.1.3'
 gem "stimulus-rails", "~> 1.3"
 gem "importmap-rails", "~> 2.0"
-gem 'commonmarker', '~> 2.3.0'
+gem 'commonmarker', '~> 2.3.2'
 gem "doorkeeper", "~> 5.8.2"
 gem "bcrypt", require: false
 gem "doorkeeper-i18n", "~> 5.2"

--- a/lib/redmine/wiki_formatting/common_mark/formatter.rb
+++ b/lib/redmine/wiki_formatting/common_mark/formatter.rb
@@ -35,6 +35,7 @@ module Redmine
           tasklist: true,
           shortcodes: false,
           alerts: true,
+          cjk_friendly_emphasis: true,
         }.freeze,
 
         # https://github.com/gjtorikian/commonmarker#parse-options

--- a/test/unit/lib/redmine/wiki_formatting/common_mark/formatter_test.rb
+++ b/test/unit/lib/redmine/wiki_formatting/common_mark/formatter_test.rb
@@ -342,6 +342,13 @@ class Redmine::WikiFormatting::CommonMark::FormatterTest < ActionView::TestCase
       assert_not_include 'markdown-alert', html
     end
 
+    def test_should_enable_cjk_friendly_emphasis_extension
+      assert_equal(
+        "<p><strong>この文は重要です。</strong>而且，<strong>这句话也非常重要。</strong>이 문장은 중요하지 않습니다.</p>",
+        to_html("**この文は重要です。**而且，**这句话也非常重要。**이 문장은 중요하지 않습니다.")
+      )
+    end
+
     private
 
     def assert_section_with_hash(expected, text, index)


### PR DESCRIPTION
* https://github.com/commonmark/commonmark-spec/issues/650
* https://github.com/tats-u/markdown-cjk-friendly
* https://github.com/gjtorikian/commonmarker?tab=readme-ov-file#extension-options
* https://github.com/gjtorikian/commonmarker/releases/tag/v2.3.2
* https://github.com/tats-u/markdown-cjk-friendly/blob/main/specification.md
* 他の言語や仕様に影響しない
https://github.com/tats-u/markdown-cjk-friendly?tab=readme-ov-file#compatibility-with-the-other-languages--%E4%BB%96%E8%A8%80%E8%AA%9E%E3%81%A8%E3%81%AE%E4%BA%92%E6%8F%9B%E6%80%A7--%E4%B8%8E%E5%85%B6%E4%BB%96%E8%AF%AD%E8%A8%80%E7%9A%84%E5%85%BC%E5%AE%B9%E6%80%A7--%EB%8B%A4%EB%A5%B8-%EC%96%B8%EC%96%B4%EC%99%80%EC%9D%98-%ED%98%B8%ED%99%98%EC%84%B1

Input:
<img width="685" height="503" alt="image" src="https://github.com/user-attachments/assets/1da4e5c8-c08f-40b3-b50d-23fabe512746" />

Before:
<img width="685" height="503" alt="image" src="https://github.com/user-attachments/assets/41d2b506-f23f-4ed6-bd7d-b500684215b2" />

After:
<img width="685" height="503" alt="image" src="https://github.com/user-attachments/assets/5ebfda35-e858-4f21-8a52-c703f0e4deab" />
