### PR TITLE
Replace tooltip with Stimulus controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,45 +1,12 @@
-# Repository Guidelines
+# AGENTS.md
 
-## プロジェクト構成とモジュール配置
+## 開発
 
-`app/` が主要な Rails アプリケーションコードを保持し、`app/models`、`app/controllers`、`app/views` で役割が分かれます。共有ロジックは `lib/`、Redmine プラグインは `plugins/`、データベース関連は `db/`、静的アセットは `public/` と `app/assets/` に配置されています。システムテストと単体テストは `test/` 配下にまとまり、追加ドキュメントは `doc/` と `extra/` を確認してください。
+* `bin/rails test` など Rails のコマンドは redmined CLI https://github.com/hidakatsuya/redmined を使って実行する。その際 `redmined -T bin/rails test` のように `-T` オプションをつけて実行する
+* redmined CLI は Apple container https://github.com/apple/container で動作させる。もし、Apple container が起動していない場合は、`container system start` で起動する
 
-## ビルド・テスト・開発コマンド
+## 作業記録と後続の開発に影響を与える意思決定の扱い
 
-Redmineの開発は redmined CLI https://github.com/hidakatsuya/redmined を使用します。
-
-- `redmined -T bundle install`, `redmined -T yarn install` : Ruby とフロントエンド依存関係を同期します。
-- `redmined -T bin/rails server` : ローカル開発サーバーを起動します。
-- `redmined -T bin/rails db:migrate` : スキーマを最新状態に更新します（必要に応じて `RAILS_ENV=test` を指定）。
-- `redmined -T bin/rails test` : Minitest ベースのテストスイートを実行します。
-- `redmined -T bin/rails assets:clobber assets:precompile` : フロントエンドアセットの再生成と検証を行います。
-- `redmined -T bundle exec rubocop` : コードスタイルをチェックします。
-- `redmined -T bundle exec rubocop -a` : コードスタイルを自動修正します。
-- `redmined -T bin/importmap pin <npm-package>` : importmap-rails を使用して npm パッケージをピン留めします。
-
-その他、Rails などのコマンドを実行する場合は、すべて `redmined -T` を付けて実行してください。
-
-## コーディングスタイルと命名規約
-
-Ruby は RuboCop 基準（2 スペースインデント、snake_case メソッド/変数、CamelCase クラス）に合わせます。ERB テンプレートは HTML5 構造を保ち、必要な場合のみ `<%=` を使用します。JavaScript/CSS は `app/assets` で管理し、Stylelint 設定に従って BEM に近い命名と 2 スペースインデントを統一します。翻訳キーは `config/locales/*.yml` に snake_case で追加してください。
-
-JavaScript については、古くから `app/assets` で管理されていますが、少しずつ Stimulus コントローラーへの移行を進めています。それらは `app/javascripts` に配置されます。基本的に JavaScript を伴う機能追加は、Stimulus コントローラーで実装します。また、ライブラリを使う場合も、importmap-rails https://github.com/rails/importmap-rails を使用して `config/importmap.rb` に追加して使用します。
-
-## テストガイドライ
-
-標準テストフレームワークは ActiveSupport::TestCase です。テストファイルは、`test/` 配下に次のように分類して配置されています。これら以外の空のディレクトリは使用しません。
-
-- `test/fixtures` : テストフィクスチャの定義
-- `test/functional` : 主にコントローラーテストを配置
-- `test/generators` : ジェネレーターのテストを配置
-- `test/helpers` : ヘルパーのテストを配置
-- `test/integration` : 結合テストを配置
-- `test/mailers` : メーラーのテストを配置
-- `test/system` : システムテストを配置
-- `test/unit` : モデル、ジョブ、`lib/redmine` など、上記以外のテストを配置
-
-`test/models/foo_test.rb` のように対象ごとにディレクトリを揃え、メソッドは `test 'subject'` で説明します。新機能は必要なテストをすべて用意し、それらのテストでカバーできない動作はシステムテストを用意します。リグレッションにはフィクスチャを活用し、DB 変更を伴う場合はテスト環境でのマイグレーションを確認してください。フィクスチャは、`ActiveSupport::TestCase` にて、`fixtures :all` を宣言して常にすべてのフィクスチャをロードしているので、テストで個別に `fixtures` を宣言する必要はありません。
-
-## コミットとプルリクエスト方針
-
-コミットメッセージは短い要約（英語 imperative）と必要なら詳細本文を追加してください。このリポジトリは、redmine/redmine のフォークリポジトリですが、redmine/redmine はプロリクエストを受け付けていないため、指示するまでプルリクエストは作成しないでください。
+* 作業中にコンテキストの圧縮が起こると作業に必要な重要な情報が欠落する場合がある。それを回避するため、重要な意思決定や必要な作業記録は、指示された pull request または Issue のコメントに記録する
+* 指示された pull request または issue のコメントへの追加は、hidakatsuya/redmine リポジトリのみ許可する。それ以外のリポジトリにはコメントしてはならない
+* 作業を始める際は、指示された pull request または issue のコメントを確認して作業を行うこと

--- a/app/assets/javascripts/application-legacy.js
+++ b/app/assets/javascripts/application-legacy.js
@@ -1288,22 +1288,6 @@ function setupWikiTableSortableHeader() {
   });
 }
 
-function setupHoverTooltips(container) {
-  $(container || 'body').find("[title]:not(.no-tooltip)").tooltip({
-    show: {
-      delay: 400
-    },
-    position: {
-      my: "center bottom-5",
-      at: "center top"
-    }
-  });
-}
-function removeHoverTooltips(container) {
-  $(container || 'body').find("[title]:not(.no-tooltip)").tooltip('destroy')
-}
-$(function() { setupHoverTooltips(); });
-
 function inlineAutoComplete(element) {
     'use strict';
 

--- a/app/assets/javascripts/application-legacy.js
+++ b/app/assets/javascripts/application-legacy.js
@@ -690,6 +690,7 @@ function setupCopyButtonsToPreElements() {
 
     const copyButton = document.createElement("a");
     copyButton.title = rm.I18n.buttonCopy;
+    copyButton.dataset.tooltipTarget = "trigger";
     copyButton.classList.add("copy-pre-content-link", "icon-only");
     copyButton.append(createSVGIcon("copy-pre-content"));
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1685,6 +1685,23 @@ table.cal div.tooltip:hover span.tip {
   inset-block-start: 25px;
 }
 
+.tooltip-body {
+  position: absolute;
+  z-index: 10000;
+  inline-size: max-content;
+  max-inline-size: 280px;
+  padding: 4px 8px;
+  border-radius: 3px;
+  background: var(--oc-black);
+  color: var(--oc-white);
+  font-size: 0.75rem;
+  font-weight: normal;
+  line-height: 1.4;
+  text-align: start;
+  white-space: pre-wrap;
+  pointer-events: none;
+}
+
 img.ui-datepicker-trigger {
   cursor: pointer;
   vertical-align: middle;
@@ -2091,17 +2108,6 @@ div.wiki .task-list input.task-list-item-checkbox {
 }
 .badge-issues-count {
   background: var(--oc-gray-2);
-}
-
-/***** Tooltips *****/
-.ui-tooltip {
-  background: var(--oc-black);
-  color: var(--oc-white);
-  border-radius: 3px;
-  border: 0;
-  box-shadow: none;
-  white-space: pre-wrap;
-  pointer-events: none;
 }
 
 /***** SVG Icons *****/

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -163,7 +163,7 @@ class IssuesController < ApplicationController
           flash[:notice] =
             l(:notice_issue_successful_create,
               :id => view_context.link_to("##{@issue.id}", issue_path(@issue),
-                                          :title => @issue.subject))
+                                          :data => view_context.tooltip_stimulus_attributes(text: @issue.subject)))
           redirect_after_create
         end
         format.api do

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -162,8 +162,9 @@ class IssuesController < ApplicationController
           render_attachment_warning_if_needed(@issue)
           flash[:notice] =
             l(:notice_issue_successful_create,
-              :id => view_context.link_to("##{@issue.id}", issue_path(@issue),
-                                          :data => view_context.tooltip_stimulus_attributes(text: @issue.subject)))
+              :id => view_context.link_to(
+                "##{@issue.id}", issue_path(@issue), **view_context.tooltip_options(@issue.subject)
+              ))
           redirect_after_create
         end
         format.api do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -120,7 +120,8 @@ module ApplicationHelper
     end
     only_path = options[:only_path].nil? ? true : options[:only_path]
     s = link_to(text, issue_url(issue, :only_path => only_path),
-                :class => issue.css_classes, :title => title)
+                :class => issue.css_classes,
+                :data => tooltip_stimulus_attributes(text: title))
     s << h(": #{subject}") if subject
     s = h("#{issue.project} - ") + s if options[:project]
     s
@@ -166,7 +167,7 @@ module ApplicationHelper
       {:controller => 'repositories', :action => 'revision',
        :id => repository.project,
        :repository_id => repository.identifier_param, :rev => rev},
-      :title => l(:label_revision_id, format_revision(revision)),
+      :data => tooltip_stimulus_attributes(text: l(:label_revision_id, format_revision(revision))),
       :accesskey => options[:accesskey]
     )
   end
@@ -216,7 +217,7 @@ module ApplicationHelper
   def link_to_version(version, options = {})
     return '' unless version && version.is_a?(Version)
 
-    options = {:title => format_date(version.effective_date)}.merge(options)
+    options[:data] = tooltip_stimulus_attributes(text: format_date(version.effective_date))
     link_to_if version.visible?, format_version_name(version), version_path(version), options
   end
 
@@ -319,7 +320,7 @@ module ApplicationHelper
             object,
             :class => ['icon-only', 'icon-download'],
             :icon => 'download',
-            :title => l(:button_download),
+            :data => tooltip_stimulus_attributes(text: l(:button_download)),
             :download => true
           ),
           class: 'attachment-filename'
@@ -353,7 +354,8 @@ module ApplicationHelper
   def thumbnail_tag(attachment)
     thumbnail_size = Setting.thumbnails_size.to_i
     thumbnail_path = thumbnail_path(attachment, :size => thumbnail_size * 2)
-    tag.div class: 'thumbnail', title: attachment.filename do
+    tag.div class: 'thumbnail',
+            data: tooltip_stimulus_attributes(text: attachment.filename) do
       link_to(
         image_tag(
           thumbnail_path,
@@ -500,16 +502,11 @@ module ApplicationHelper
           href = {:controller => 'wiki', :action => 'show',
                   :project_id => page.project, :id => page.title, :version => nil}
         end
-        content <<
-          link_to(
-            h(page.pretty_title),
-            href,
-            :title => (if options[:timestamp] && page.updated_on
-                         l(:label_updated_time, distance_of_time_in_words(Time.now, page.updated_on))
-                       else
-                         nil
-                       end)
-          )
+        tooltip =
+          if options[:timestamp] && page.updated_on
+            l(:label_updated_time, distance_of_time_in_words(Time.now, page.updated_on))
+          end
+        content << link_to(h(page.pretty_title), href, :data => tooltip_stimulus_attributes(text: tooltip))
         content << "\n" + render_page_hierarchy(pages, page.id, options) if pages[page.id]
         content << "</li>\n"
       end
@@ -585,7 +582,7 @@ module ApplicationHelper
       padding = level * 16
       text = content_tag('span', project.name, :style => "padding-inline-start:#{padding}px;")
       s << link_to(text, project_path(project, :jump => jump),
-                   :title => project.name,
+                   :data => tooltip_stimulus_attributes(text: project.name),
                    :class => (project == selected ? 'selected' : nil))
     end
     [
@@ -767,9 +764,9 @@ module ApplicationHelper
     if @project
       link_to(text,
               project_activity_path(@project, :from => User.current.time_to_date(time)),
-              :title => format_time(time))
+              :data => tooltip_stimulus_attributes(text: format_time(time)))
     else
-      content_tag('abbr', text, :title => format_time(time))
+      content_tag('abbr', text, :data => tooltip_stimulus_attributes(text: format_time(time)))
     end
   end
 
@@ -790,11 +787,13 @@ module ApplicationHelper
     data = {
       :reorder_url => options[:url] || url_for(object),
       :reorder_param => options[:param] || object.class.name.underscore
-    }
+    }.merge(
+      tooltip_stimulus_attributes(text: l(:button_sort))
+    )
+
     content_tag('span', sprite_icon('reorder', ''),
                 :class => "icon-only icon-sort-handle sort-handle",
-                :data => data,
-                :title => l(:button_sort))
+                :data => data)
   end
 
   def breadcrumb(*args)
@@ -872,7 +871,7 @@ module ApplicationHelper
     if content.present?
       trigger =
         content_tag('span', sprite_icon('3-bullets', l(:button_actions)), :class => 'icon-only icon-actions',
-                    :title => l(:button_actions))
+                    :data => tooltip_stimulus_attributes(text: l(:button_actions)))
       trigger = content_tag('span', trigger, :class => 'drdn-trigger')
       content = content_tag('div', content, :class => 'drdn-items')
       content = content_tag('div', content, :class => 'drdn-content')
@@ -1152,11 +1151,11 @@ module ApplicationHelper
                                     find_by_repository_id_and_revision(repository.id, identifier))
                 link = link_to(h("#{project_prefix}#{repo_prefix}r#{identifier}"),
                                {:only_path => only_path, :controller => 'repositories',
-                                :action => 'revision', :id => project,
-                                :repository_id => repository.identifier_param,
-                                :rev => changeset.revision},
+                               :action => 'revision', :id => project,
+                               :repository_id => repository.identifier_param,
+                               :rev => changeset.revision},
                                :class => 'changeset',
-                               :title => truncate_single_line_raw(changeset.comments, 100))
+                               :data => tooltip_stimulus_attributes(text: truncate_single_line_raw(changeset.comments, 100)))
               end
             end
           elsif sep == '#' || sep == '##'
@@ -1172,12 +1171,12 @@ module ApplicationHelper
                     link_to("#{issue.tracker.name} ##{oid}#{comment_suffix}: #{issue.subject}",
                             url,
                             :class => issue.css_classes,
-                            :title => "#{l(:field_status)}: #{issue.status.name}")
+                            :data => tooltip_stimulus_attributes(text: "#{l(:field_status)}: #{issue.status.name}"))
                   else
                     link_to("##{oid}#{comment_suffix}",
                             url,
                             :class => issue.css_classes,
-                            :title => "#{issue.tracker.name}: #{issue.subject.truncate(100)} (#{issue.status.name})")
+                            :data => tooltip_stimulus_attributes(text: "#{issue.tracker.name}: #{issue.subject.truncate(100)} (#{issue.status.name})"))
                   end
               elsif identifier == 'note'
                 link = link_to("#note-#{comment_id}", "#note-#{comment_id}")
@@ -1262,7 +1261,7 @@ module ApplicationHelper
                          :repository_id => repository.identifier_param,
                         :rev => changeset.identifier},
                         :class => 'changeset',
-                        :title => truncate_single_line_raw(changeset.comments, 100)
+                        :data => tooltip_stimulus_attributes(text: truncate_single_line_raw(changeset.comments, 100))
                       )
                   end
                 else
@@ -1368,7 +1367,7 @@ module ApplicationHelper
               :section => @current_section),
             :class => 'icon-only icon-edit'),
           :class => "contextual heading-#{level}",
-          :title => l(:button_edit_section),
+          :data => tooltip_stimulus_attributes(text: l(:button_edit_section)),
           :id => "section-#{@current_section}") + heading.html_safe
       else
         heading
@@ -1409,6 +1408,16 @@ module ApplicationHelper
       action: 'beforeinput->list-autofill#handleBeforeInput paste->table-paste#handlePaste',
       list_autofill_text_formatting_param: Setting.text_formatting,
       table_paste_text_formatting_param: Setting.text_formatting
+    }
+  end
+
+  def tooltip_stimulus_attributes(text:)
+    return {} if text.blank?
+
+    {
+      controller: 'tooltip',
+      action: 'mouseenter->tooltip#show mouseleave->tooltip#hide',
+      tooltip_text_value: text
     }
   end
 
@@ -1581,7 +1590,10 @@ module ApplicationHelper
   end
 
   def link_to_context_menu
-    link_to sprite_icon('3-bullets', l(:button_actions)), '#', title: l(:button_actions), class: 'icon-only icon-actions js-contextmenu '
+    link_to sprite_icon('3-bullets', l(:button_actions)),
+            '#',
+            class: 'icon-only icon-actions js-contextmenu ',
+            data: tooltip_stimulus_attributes(text: l(:button_actions))
   end
 
   # Helper to render JSON in views
@@ -1610,7 +1622,7 @@ module ApplicationHelper
     css_classes += ' ' + options[:class] if options[:class]
     link_to_function sprite_icon('checked', ''),
                      "toggleCheckboxesBySelector('#{selector}')",
-                     :title => "#{l(:button_check_all)} / #{l(:button_uncheck_all)}",
+                     :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}"),
                      :class => css_classes
   end
 
@@ -1628,19 +1640,19 @@ module ApplicationHelper
         'tr',
         (if pcts[0] > 0
            content_tag('td', '', :style => "width: #{pcts[0]}%;",
-                       :class => 'closed', :title => titles[0])
+                       :class => 'closed', :data => tooltip_stimulus_attributes(text: titles[0]))
          else
            ''.html_safe
          end) +
         (if pcts[1] > 0
            content_tag('td', '', :style => "width: #{pcts[1]}%;",
-                      :class => 'done', :title => titles[1])
+                      :class => 'done', :data => tooltip_stimulus_attributes(text: titles[1]))
          else
            ''.html_safe
          end) +
         (if pcts[2] > 0
            content_tag('td', '', :style => "width: #{pcts[2]}%;",
-                                   :class => 'todo', :title => titles[2])
+                                   :class => 'todo', :data => tooltip_stimulus_attributes(text: titles[2]))
          else
            ''.html_safe
          end)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -121,7 +121,7 @@ module ApplicationHelper
     only_path = options[:only_path].nil? ? true : options[:only_path]
     s = link_to(text, issue_url(issue, :only_path => only_path),
                 :class => issue.css_classes,
-                :data => tooltip_stimulus_attributes(text: title))
+                **tooltip_options(title))
     s << h(": #{subject}") if subject
     s = h("#{issue.project} - ") + s if options[:project]
     s
@@ -167,7 +167,7 @@ module ApplicationHelper
       {:controller => 'repositories', :action => 'revision',
        :id => repository.project,
        :repository_id => repository.identifier_param, :rev => rev},
-      :data => tooltip_stimulus_attributes(text: l(:label_revision_id, format_revision(revision))),
+      **tooltip_options(l(:label_revision_id, format_revision(revision))),
       :accesskey => options[:accesskey]
     )
   end
@@ -217,7 +217,8 @@ module ApplicationHelper
   def link_to_version(version, options = {})
     return '' unless version && version.is_a?(Version)
 
-    options[:data] = tooltip_stimulus_attributes(text: format_date(version.effective_date))
+    title = options.fetch(:title, format_date(version.effective_date))
+    options = tooltip_options(title, options.except(:title))
     link_to_if version.visible?, format_version_name(version), version_path(version), options
   end
 
@@ -320,7 +321,7 @@ module ApplicationHelper
             object,
             :class => ['icon-only', 'icon-download'],
             :icon => 'download',
-            :data => tooltip_stimulus_attributes(text: l(:button_download)),
+            **tooltip_options(l(:button_download)),
             :download => true
           ),
           class: 'attachment-filename'
@@ -355,7 +356,7 @@ module ApplicationHelper
     thumbnail_size = Setting.thumbnails_size.to_i
     thumbnail_path = thumbnail_path(attachment, :size => thumbnail_size * 2)
     tag.div class: 'thumbnail',
-            data: tooltip_stimulus_attributes(text: attachment.filename) do
+            **tooltip_options(attachment.filename) do
       link_to(
         image_tag(
           thumbnail_path,
@@ -506,7 +507,7 @@ module ApplicationHelper
           if options[:timestamp] && page.updated_on
             l(:label_updated_time, distance_of_time_in_words(Time.now, page.updated_on))
           end
-        content << link_to(h(page.pretty_title), href, :data => tooltip_stimulus_attributes(text: tooltip))
+        content << link_to(h(page.pretty_title), href, **tooltip_options(tooltip))
         content << "\n" + render_page_hierarchy(pages, page.id, options) if pages[page.id]
         content << "</li>\n"
       end
@@ -582,7 +583,7 @@ module ApplicationHelper
       padding = level * 16
       text = content_tag('span', project.name, :style => "padding-inline-start:#{padding}px;")
       s << link_to(text, project_path(project, :jump => jump),
-                   :data => tooltip_stimulus_attributes(text: project.name),
+                   **tooltip_options(project.name),
                    :class => (project == selected ? 'selected' : nil))
     end
     [
@@ -764,9 +765,9 @@ module ApplicationHelper
     if @project
       link_to(text,
               project_activity_path(@project, :from => User.current.time_to_date(time)),
-              :data => tooltip_stimulus_attributes(text: format_time(time)))
+              **tooltip_options(format_time(time)))
     else
-      content_tag('abbr', text, :data => tooltip_stimulus_attributes(text: format_time(time)))
+      content_tag('abbr', text, **tooltip_options(format_time(time)))
     end
   end
 
@@ -787,13 +788,14 @@ module ApplicationHelper
     data = {
       :reorder_url => options[:url] || url_for(object),
       :reorder_param => options[:param] || object.class.name.underscore
-    }.merge(
-      tooltip_stimulus_attributes(text: l(:button_sort))
-    )
+    }
 
     content_tag('span', sprite_icon('reorder', ''),
-                :class => "icon-only icon-sort-handle sort-handle",
-                :data => data)
+                **tooltip_options(
+                  l(:button_sort),
+                  :class => "icon-only icon-sort-handle sort-handle",
+                  :data => data
+                ))
   end
 
   def breadcrumb(*args)
@@ -871,7 +873,7 @@ module ApplicationHelper
     if content.present?
       trigger =
         content_tag('span', sprite_icon('3-bullets', l(:button_actions)), :class => 'icon-only icon-actions',
-                    :data => tooltip_stimulus_attributes(text: l(:button_actions)))
+                    **tooltip_options(l(:button_actions)))
       trigger = content_tag('span', trigger, :class => 'drdn-trigger')
       content = content_tag('div', content, :class => 'drdn-items')
       content = content_tag('div', content, :class => 'drdn-content')
@@ -1155,7 +1157,7 @@ module ApplicationHelper
                                :repository_id => repository.identifier_param,
                                :rev => changeset.revision},
                                :class => 'changeset',
-                               :data => tooltip_stimulus_attributes(text: truncate_single_line_raw(changeset.comments, 100)))
+                               **tooltip_options(truncate_single_line_raw(changeset.comments, 100)))
               end
             end
           elsif sep == '#' || sep == '##'
@@ -1171,12 +1173,12 @@ module ApplicationHelper
                     link_to("#{issue.tracker.name} ##{oid}#{comment_suffix}: #{issue.subject}",
                             url,
                             :class => issue.css_classes,
-                            :data => tooltip_stimulus_attributes(text: "#{l(:field_status)}: #{issue.status.name}"))
+                            **tooltip_options("#{l(:field_status)}: #{issue.status.name}"))
                   else
                     link_to("##{oid}#{comment_suffix}",
                             url,
                             :class => issue.css_classes,
-                            :data => tooltip_stimulus_attributes(text: "#{issue.tracker.name}: #{issue.subject.truncate(100)} (#{issue.status.name})"))
+                            **tooltip_options("#{issue.tracker.name}: #{issue.subject.truncate(100)} (#{issue.status.name})"))
                   end
               elsif identifier == 'note'
                 link = link_to("#note-#{comment_id}", "#note-#{comment_id}")
@@ -1261,7 +1263,7 @@ module ApplicationHelper
                          :repository_id => repository.identifier_param,
                         :rev => changeset.identifier},
                         :class => 'changeset',
-                        :data => tooltip_stimulus_attributes(text: truncate_single_line_raw(changeset.comments, 100))
+                        **tooltip_options(truncate_single_line_raw(changeset.comments, 100))
                       )
                   end
                 else
@@ -1367,7 +1369,7 @@ module ApplicationHelper
               :section => @current_section),
             :class => 'icon-only icon-edit'),
           :class => "contextual heading-#{level}",
-          :data => tooltip_stimulus_attributes(text: l(:button_edit_section)),
+          **tooltip_options(l(:button_edit_section)),
           :id => "section-#{@current_section}") + heading.html_safe
       else
         heading
@@ -1411,14 +1413,13 @@ module ApplicationHelper
     }
   end
 
-  def tooltip_stimulus_attributes(text:)
-    return {} if text.blank?
+  def tooltip_options(text, html_options = {})
+    return html_options if text.blank?
 
-    {
-      controller: 'tooltip',
-      action: 'mouseenter->tooltip#show mouseleave->tooltip#hide',
-      tooltip_text_value: text
-    }
+    html_options.merge(
+      title: text,
+      data: (html_options[:data] || {}).merge(tooltip_target: 'trigger')
+    )
   end
 
   unless const_defined?(:MACROS_RE)
@@ -1593,7 +1594,7 @@ module ApplicationHelper
     link_to sprite_icon('3-bullets', l(:button_actions)),
             '#',
             class: 'icon-only icon-actions js-contextmenu ',
-            data: tooltip_stimulus_attributes(text: l(:button_actions))
+            **tooltip_options(l(:button_actions))
   end
 
   # Helper to render JSON in views
@@ -1622,7 +1623,7 @@ module ApplicationHelper
     css_classes += ' ' + options[:class] if options[:class]
     link_to_function sprite_icon('checked', ''),
                      "toggleCheckboxesBySelector('#{selector}')",
-                     :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}"),
+                     **tooltip_options("#{l(:button_check_all)} / #{l(:button_uncheck_all)}"),
                      :class => css_classes
   end
 
@@ -1640,19 +1641,19 @@ module ApplicationHelper
         'tr',
         (if pcts[0] > 0
            content_tag('td', '', :style => "width: #{pcts[0]}%;",
-                       :class => 'closed', :data => tooltip_stimulus_attributes(text: titles[0]))
+                       :class => 'closed', **tooltip_options(titles[0]))
          else
            ''.html_safe
          end) +
         (if pcts[1] > 0
            content_tag('td', '', :style => "width: #{pcts[1]}%;",
-                      :class => 'done', :data => tooltip_stimulus_attributes(text: titles[1]))
+                      :class => 'done', **tooltip_options(titles[1]))
          else
            ''.html_safe
          end) +
         (if pcts[2] > 0
            content_tag('td', '', :style => "width: #{pcts[2]}%;",
-                                   :class => 'todo', :data => tooltip_stimulus_attributes(text: titles[2]))
+                                   :class => 'todo', **tooltip_options(titles[2]))
          else
            ''.html_safe
          end)

--- a/app/helpers/avatars_helper.rb
+++ b/app/helpers/avatars_helper.rb
@@ -57,7 +57,10 @@ module AvatarsHelper
   def avatar_edit_link(user, options={})
     if Setting.gravatar_enabled?
       url = Redmine::Configuration['avatar_server_url']
-      link_to avatar(user, {:title => l(:button_edit)}.merge(options)), url, :target => '_blank'
+      link_to avatar(user, options),
+              url,
+              :target => '_blank',
+              :data => tooltip_stimulus_attributes(text: l(:button_edit))
     end
   end
 
@@ -76,11 +79,12 @@ module AvatarsHelper
   def gravatar_avatar_tag(user, options)
     options[:default] = Setting.gravatar_default
     options[:class] = [GravatarHelper::DEFAULT_OPTIONS[:class], options[:class]].compact.join(' ')
+    tooltip = options.delete(:title)
 
     email = extract_email_from_user(user)
 
     if user.respond_to?(:mail)
-      options[:title] ||= user.name
+      options[:data] = tooltip_stimulus_attributes(text: tooltip || user.name)
       options[:initials] = user.initials if options[:default] == "initials" && user.initials.present?
     end
 
@@ -91,10 +95,17 @@ module AvatarsHelper
 
   def initials_avatar_tag(user, options)
     size = (options.delete(:size) || GravatarHelper::DEFAULT_OPTIONS[:size]).to_i
+    tooltip = options.delete(:title)
 
     css_class = ["avatar-color-#{user.id % 8}", "s#{size}", options[:class]].compact.join(' ')
 
-    content_tag('span', user.initials, role: 'img', class: css_class, title: options[:title])
+    content_tag(
+      'span',
+      user.initials,
+      role: 'img',
+      class: css_class,
+      data: tooltip_stimulus_attributes(text: tooltip)
+    )
   end
 
   def extract_email_from_user(user)

--- a/app/helpers/avatars_helper.rb
+++ b/app/helpers/avatars_helper.rb
@@ -60,7 +60,7 @@ module AvatarsHelper
       link_to avatar(user, options),
               url,
               :target => '_blank',
-              :data => tooltip_stimulus_attributes(text: l(:button_edit))
+              **tooltip_options(l(:button_edit))
     end
   end
 
@@ -79,14 +79,16 @@ module AvatarsHelper
   def gravatar_avatar_tag(user, options)
     options[:default] = Setting.gravatar_default
     options[:class] = [GravatarHelper::DEFAULT_OPTIONS[:class], options[:class]].compact.join(' ')
-    tooltip = options.delete(:title)
+    tooltip = options[:title]
 
     email = extract_email_from_user(user)
 
     if user.respond_to?(:mail)
-      options[:data] = tooltip_stimulus_attributes(text: tooltip || user.name)
+      tooltip ||= user.name
       options[:initials] = user.initials if options[:default] == "initials" && user.initials.present?
     end
+
+    options = tooltip_options(tooltip, options)
 
     if email.present?
       gravatar(email.to_s.downcase, options) rescue nil
@@ -104,7 +106,7 @@ module AvatarsHelper
       user.initials,
       role: 'img',
       class: css_class,
-      data: tooltip_stimulus_attributes(text: tooltip)
+      **tooltip_options(tooltip)
     )
   end
 

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -103,7 +103,7 @@ module CustomFieldsHelper
   def custom_field_name_tag(custom_field)
     title = custom_field.description.presence
     css = title ? "field-description" : nil
-    content_tag 'span', custom_field.name, :title => title, :class => css
+    content_tag 'span', custom_field.name, :class => css, :data => tooltip_stimulus_attributes(text: title)
   end
 
   # Return custom field label tag

--- a/app/helpers/custom_fields_helper.rb
+++ b/app/helpers/custom_fields_helper.rb
@@ -103,7 +103,7 @@ module CustomFieldsHelper
   def custom_field_name_tag(custom_field)
     title = custom_field.description.presence
     css = title ? "field-description" : nil
-    content_tag 'span', custom_field.name, :class => css, :data => tooltip_stimulus_attributes(text: title)
+    content_tag 'span', custom_field.name, :class => css, **tooltip_options(title)
   end
 
   # Return custom field label tag

--- a/app/helpers/email_addresses_helper.rb
+++ b/app/helpers/email_addresses_helper.rb
@@ -25,14 +25,14 @@ module EmailAddressesHelper
         sprite_icon('email', l(:label_disable_notifications)),
         user_email_address_path(address.user, address, :notify => '0'),
         :method => :put, :remote => true,
-        :title => l(:label_disable_notifications),
+        :data => tooltip_stimulus_attributes(text: l(:label_disable_notifications)),
         :class => 'icon-only icon-email')
     else
       link_to(
         sprite_icon('email-disabled', l(:label_enable_notifications)),
         user_email_address_path(address.user, address, :notify => '1'),
         :method => :put, :remote => true,
-        :title => l(:label_enable_notifications),
+        :data => tooltip_stimulus_attributes(text: l(:label_enable_notifications)),
         :class => 'icon-only icon-email-disabled')
     end
   end

--- a/app/helpers/email_addresses_helper.rb
+++ b/app/helpers/email_addresses_helper.rb
@@ -25,14 +25,14 @@ module EmailAddressesHelper
         sprite_icon('email', l(:label_disable_notifications)),
         user_email_address_path(address.user, address, :notify => '0'),
         :method => :put, :remote => true,
-        :data => tooltip_stimulus_attributes(text: l(:label_disable_notifications)),
+        **tooltip_options(l(:label_disable_notifications)),
         :class => 'icon-only icon-email')
     else
       link_to(
         sprite_icon('email-disabled', l(:label_enable_notifications)),
         user_email_address_path(address.user, address, :notify => '1'),
         :method => :put, :remote => true,
-        :data => tooltip_stimulus_attributes(text: l(:label_enable_notifications)),
+        **tooltip_options(l(:label_enable_notifications)),
         :class => 'icon-only icon-email-disabled')
     end
   end

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -128,8 +128,7 @@ module IssuesHelper
                :back_url => issue_path(issue.id), :no_flash => '1'}
             ),
             :method => :put,
-            :data => {:confirm => l(:text_are_you_sure)},
-            :title => l(:label_subtask_remove),
+            :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:label_subtask_remove))),
             :class => 'icon-only icon-link-break'
           )
         else
@@ -229,8 +228,7 @@ module IssuesHelper
             relation_path(relation, issue_id: issue.id),
             :remote => true,
             :method => :delete,
-            :data => {:confirm => l(:text_are_you_sure)},
-            :title => l(:label_relation_remove),
+            :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:label_relation_remove))),
             :class => 'icon-only icon-link-break'
           )
         else
@@ -619,7 +617,11 @@ module IssuesHelper
         value = link_to_attachment(atta, only_path: options[:only_path])
         if options[:only_path] != false
           value += ' '
-          value += link_to_attachment atta, class: 'icon-only icon-download', title: l(:button_download), download: true, icon: 'download'
+          value += link_to_attachment atta,
+                                      class: 'icon-only icon-download',
+                                      data: tooltip_stimulus_attributes(text: l(:button_download)),
+                                      download: true,
+                                      icon: 'download'
         end
       else
         value = content_tag("i", h(value)) if value
@@ -636,7 +638,7 @@ module IssuesHelper
             l(:label_diff),
             diff_journal_url(detail.journal_id, :detail_id => detail.id,
                              :only_path => options[:only_path]),
-            :title => l(:label_view_diff))
+            :data => tooltip_stimulus_attributes(text: l(:label_view_diff)))
         s << " (#{diff_link})"
       end
       s.html_safe

--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -128,7 +128,10 @@ module IssuesHelper
                :back_url => issue_path(issue.id), :no_flash => '1'}
             ),
             :method => :put,
-            :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:label_subtask_remove))),
+            **tooltip_options(
+              l(:label_subtask_remove),
+              :data => {:confirm => l(:text_are_you_sure)}
+            ),
             :class => 'icon-only icon-link-break'
           )
         else
@@ -228,7 +231,10 @@ module IssuesHelper
             relation_path(relation, issue_id: issue.id),
             :remote => true,
             :method => :delete,
-            :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:label_relation_remove))),
+            **tooltip_options(
+              l(:label_relation_remove),
+              :data => {:confirm => l(:text_are_you_sure)}
+            ),
             :class => 'icon-only icon-link-break'
           )
         else
@@ -619,7 +625,7 @@ module IssuesHelper
           value += ' '
           value += link_to_attachment atta,
                                       class: 'icon-only icon-download',
-                                      data: tooltip_stimulus_attributes(text: l(:button_download)),
+                                      **tooltip_options(l(:button_download)),
                                       download: true,
                                       icon: 'download'
         end
@@ -638,7 +644,7 @@ module IssuesHelper
             l(:label_diff),
             diff_journal_url(detail.journal_id, :detail_id => detail.id,
                              :only_path => options[:only_path]),
-            :data => tooltip_stimulus_attributes(text: l(:label_view_diff)))
+            **tooltip_options(l(:label_view_diff)))
         s << " (#{diff_link})"
       end
       s.html_safe

--- a/app/helpers/journals_helper.rb
+++ b/app/helpers/journals_helper.rb
@@ -36,7 +36,7 @@ module JournalsHelper
     if journal.attachments.size > 1
       dropbown_links << link_to(sprite_icon('download', l(:label_download_all_attachments)),
                                 container_attachments_download_path(journal),
-                                :title => l(:label_download_all_attachments),
+                                :data => tooltip_stimulus_attributes(text: l(:label_download_all_attachments)),
                                 :class => 'icon icon-download'
                                )
     end
@@ -53,7 +53,7 @@ module JournalsHelper
                          edit_journal_path(journal),
                          :remote => true,
                          :method => 'get',
-                         :title => l(:button_edit),
+                         :data => tooltip_stimulus_attributes(text: l(:button_edit)),
                          :class => 'icon-only icon-edit'
                         )
         dropbown_links << link_to(sprite_icon('del', l(:button_delete)),
@@ -82,6 +82,12 @@ module JournalsHelper
   def render_journal_update_info(journal)
     return if journal.created_on == journal.updated_on
 
-    content_tag('span', "· #{l(:label_edited)}", :title => l(:label_time_by_author, :time => format_time(journal.updated_on), :author => journal.updated_by), :class => 'update-info')
+    content_tag(
+      'span', "· #{l(:label_edited)}",
+      :data => tooltip_stimulus_attributes(
+        text: l(:label_time_by_author, :time => format_time(journal.updated_on), :author => journal.updated_by)
+      ),
+      :class => 'update-info'
+    )
   end
 end

--- a/app/helpers/journals_helper.rb
+++ b/app/helpers/journals_helper.rb
@@ -36,7 +36,7 @@ module JournalsHelper
     if journal.attachments.size > 1
       dropbown_links << link_to(sprite_icon('download', l(:label_download_all_attachments)),
                                 container_attachments_download_path(journal),
-                                :data => tooltip_stimulus_attributes(text: l(:label_download_all_attachments)),
+                                **tooltip_options(l(:label_download_all_attachments)),
                                 :class => 'icon icon-download'
                                )
     end
@@ -53,7 +53,7 @@ module JournalsHelper
                          edit_journal_path(journal),
                          :remote => true,
                          :method => 'get',
-                         :data => tooltip_stimulus_attributes(text: l(:button_edit)),
+                         **tooltip_options(l(:button_edit)),
                          :class => 'icon-only icon-edit'
                         )
         dropbown_links << link_to(sprite_icon('del', l(:button_delete)),
@@ -84,8 +84,8 @@ module JournalsHelper
 
     content_tag(
       'span', "· #{l(:label_edited)}",
-      :data => tooltip_stimulus_attributes(
-        text: l(:label_time_by_author, :time => format_time(journal.updated_on), :author => journal.updated_by)
+      **tooltip_options(
+        l(:label_time_by_author, :time => format_time(journal.updated_on), :author => journal.updated_by)
       ),
       :class => 'update-info'
     )

--- a/app/helpers/my_helper.rb
+++ b/app/helpers/my_helper.rb
@@ -34,11 +34,15 @@ module MyHelper
   def render_block(block, user)
     content = render_block_content(block, user)
     if content.present?
-      handle = content_tag('span', sprite_icon('reorder', ''), :class => 'icon-only icon-sort-handle sort-handle', :title => l(:button_move))
+      handle =
+        content_tag('span', sprite_icon('reorder', ''),
+                    :class => 'icon-only icon-sort-handle sort-handle',
+                    :data => tooltip_stimulus_attributes(text: l(:button_move)))
       close = link_to(sprite_icon('close', l(:button_delete)),
                       {:action => "remove_block", :block => block},
                       :remote => true, :method => 'post',
-                      :class => "icon-only icon-close", :title => l(:button_delete))
+                      :class => "icon-only icon-close",
+                      :data => tooltip_stimulus_attributes(text: l(:button_delete)))
       content = content_tag('div', handle + close, :class => 'contextual') + content
 
       content_tag('div', content, :class => "mypage-box", :id => "block-#{block}")

--- a/app/helpers/my_helper.rb
+++ b/app/helpers/my_helper.rb
@@ -37,12 +37,12 @@ module MyHelper
       handle =
         content_tag('span', sprite_icon('reorder', ''),
                     :class => 'icon-only icon-sort-handle sort-handle',
-                    :data => tooltip_stimulus_attributes(text: l(:button_move)))
+                    **tooltip_options(l(:button_move)))
       close = link_to(sprite_icon('close', l(:button_delete)),
                       {:action => "remove_block", :block => block},
                       :remote => true, :method => 'post',
                       :class => "icon-only icon-close",
-                      :data => tooltip_stimulus_attributes(text: l(:button_delete)))
+                      **tooltip_options(l(:button_delete)))
       content = content_tag('div', handle + close, :class => 'contextual') + content
 
       content_tag('div', content, :class => "mypage-box", :id => "block-#{block}")

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -218,7 +218,7 @@ module QueriesHelper
       sort_param = {param_key => query.sort_criteria.add(column.name, order).to_param}
       sort_param = {$1 => {$2 => sort_param.values.first}} while sort_param.keys.first.to_s =~ /^(.+)\[(.+)\]$/
       link_options = {
-        :title => l(:label_sort_by, "\"#{column.caption}\""),
+        :data => tooltip_stimulus_attributes(text: l(:label_sort_by, "\"#{column.caption}\"")),
         :class => css
       }
       if options[:sort_link_options]
@@ -508,8 +508,9 @@ module QueriesHelper
                       link_to(query.name,
                               url_params.merge(:query_id => query),
                               :class => css,
-                              :title => query.description,
-                              :data => { :disable_with => CGI.escapeHTML(query.name) }) +
+                              :data => {
+                                :disable_with => CGI.escapeHTML(query.name)
+                              }.merge(tooltip_stimulus_attributes(text: query.description))) +
                         clear_link.html_safe)
         end.join("\n").html_safe,
         :class => 'queries'
@@ -521,7 +522,7 @@ module QueriesHelper
       sprite_icon('clear-query', l(:button_clear)),
       params,
       :class => 'icon-only icon-clear-query',
-      :title => l(:button_clear)
+      :data => tooltip_stimulus_attributes(text: l(:button_clear))
     )
   end
 

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -218,7 +218,7 @@ module QueriesHelper
       sort_param = {param_key => query.sort_criteria.add(column.name, order).to_param}
       sort_param = {$1 => {$2 => sort_param.values.first}} while sort_param.keys.first.to_s =~ /^(.+)\[(.+)\]$/
       link_options = {
-        :data => tooltip_stimulus_attributes(text: l(:label_sort_by, "\"#{column.caption}\"")),
+        **tooltip_options(l(:label_sort_by, "\"#{column.caption}\"")),
         :class => css
       }
       if options[:sort_link_options]
@@ -507,10 +507,11 @@ module QueriesHelper
           content_tag('li',
                       link_to(query.name,
                               url_params.merge(:query_id => query),
-                              :class => css,
-                              :data => {
-                                :disable_with => CGI.escapeHTML(query.name)
-                              }.merge(tooltip_stimulus_attributes(text: query.description))) +
+                              **tooltip_options(
+                                query.description,
+                                :class => css,
+                                :data => {:disable_with => CGI.escapeHTML(query.name)}
+                              )) +
                         clear_link.html_safe)
         end.join("\n").html_safe,
         :class => 'queries'
@@ -522,7 +523,7 @@ module QueriesHelper
       sprite_icon('clear-query', l(:button_clear)),
       params,
       :class => 'icon-only icon-clear-query',
-      :data => tooltip_stimulus_attributes(text: l(:button_clear))
+      **tooltip_options(l(:button_clear))
     )
   end
 

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -56,7 +56,7 @@ module ReactionsHelper
         reaction_path(reaction, object_type: object.class.name, object_id: object),
         remote: true, method: :delete,
         class: ['icon', 'reaction-button', 'reacted', { 'has-reactions': count.nonzero? }],
-        title: tooltip
+        data: tooltip_stimulus_attributes(text: tooltip)
       )
     end
   end
@@ -68,14 +68,17 @@ module ReactionsHelper
         reactions_path(object_type: object.class.name, object_id: object),
         remote: true, method: :post,
         class: ['icon', 'reaction-button', { 'has-reactions': count.nonzero? }],
-        title: tooltip
+        data: tooltip_stimulus_attributes(text: tooltip)
       )
     end
   end
 
   def reaction_button_readonly(object, count, tooltip)
     reaction_button_wrapper object do
-      tag.span(class: ['icon', 'reaction-button', 'readonly', { 'has-reactions': count.nonzero? }], title: tooltip) do
+      tag.span(
+        class: ['icon', 'reaction-button', 'readonly', { 'has-reactions': count.nonzero? }],
+        data: tooltip_stimulus_attributes(text: tooltip)
+      ) do
         sprite_icon('thumb-up', count.nonzero?)
       end
     end

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -56,7 +56,7 @@ module ReactionsHelper
         reaction_path(reaction, object_type: object.class.name, object_id: object),
         remote: true, method: :delete,
         class: ['icon', 'reaction-button', 'reacted', { 'has-reactions': count.nonzero? }],
-        data: tooltip_stimulus_attributes(text: tooltip)
+        **tooltip_options(tooltip)
       )
     end
   end
@@ -68,7 +68,7 @@ module ReactionsHelper
         reactions_path(object_type: object.class.name, object_id: object),
         remote: true, method: :post,
         class: ['icon', 'reaction-button', { 'has-reactions': count.nonzero? }],
-        data: tooltip_stimulus_attributes(text: tooltip)
+        **tooltip_options(tooltip)
       )
     end
   end
@@ -77,7 +77,7 @@ module ReactionsHelper
     reaction_button_wrapper object do
       tag.span(
         class: ['icon', 'reaction-button', 'readonly', { 'has-reactions': count.nonzero? }],
-        data: tooltip_stimulus_attributes(text: tooltip)
+        **tooltip_options(tooltip)
       ) do
         sprite_icon('thumb-up', count.nonzero?)
       end

--- a/app/helpers/trackers_helper.rb
+++ b/app/helpers/trackers_helper.rb
@@ -21,6 +21,6 @@ module TrackersHelper
   def tracker_name_tag(tracker)
     title = tracker.description.presence
     css = title ? "field-description" : nil
-    content_tag 'span', tracker.name, :class => css, :title => title
+    content_tag 'span', tracker.name, :class => css, :data => tooltip_stimulus_attributes(text: title)
   end
 end

--- a/app/helpers/trackers_helper.rb
+++ b/app/helpers/trackers_helper.rb
@@ -21,6 +21,6 @@ module TrackersHelper
   def tracker_name_tag(tracker)
     title = tracker.description.presence
     css = title ? "field-description" : nil
-    content_tag 'span', tracker.name, :class => css, :data => tooltip_stimulus_attributes(text: title)
+    content_tag 'span', tracker.name, :class => css, **tooltip_options(title)
   end
 end

--- a/app/helpers/watchers_helper.rb
+++ b/app/helpers/watchers_helper.rb
@@ -55,7 +55,12 @@ module WatchersHelper
       s << avatar(user, :size => "16").to_s if user.is_a?(User)
       s << link_to_principal(user, class: user.class.to_s.downcase)
       if object.respond_to?(:visible?) && user.is_a?(User) && !object.visible?(user)
-        s << content_tag('span', sprite_icon('warning', l(:notice_invalid_watcher)), class: 'icon-only icon-warning', title: l(:notice_invalid_watcher))
+        s << content_tag(
+          'span',
+          sprite_icon('warning', l(:notice_invalid_watcher)),
+          class: 'icon-only icon-warning',
+          data: tooltip_stimulus_attributes(text: l(:notice_invalid_watcher))
+        )
       end
       if remove_allowed
         url = {:controller => 'watchers',
@@ -67,7 +72,7 @@ module WatchersHelper
         s << link_to(sprite_icon('link-break', l(:button_remove)), url,
                      :remote => true, :method => 'delete',
                      :class => "delete icon-only icon-link-break",
-                     :title => l(:button_remove))
+                     :data => tooltip_stimulus_attributes(text: l(:button_remove)))
       end
       content << content_tag('li', s, :class => "user-#{user.id}")
     end

--- a/app/helpers/watchers_helper.rb
+++ b/app/helpers/watchers_helper.rb
@@ -59,7 +59,7 @@ module WatchersHelper
           'span',
           sprite_icon('warning', l(:notice_invalid_watcher)),
           class: 'icon-only icon-warning',
-          data: tooltip_stimulus_attributes(text: l(:notice_invalid_watcher))
+          **tooltip_options(l(:notice_invalid_watcher))
         )
       end
       if remove_allowed
@@ -72,7 +72,7 @@ module WatchersHelper
         s << link_to(sprite_icon('link-break', l(:button_remove)), url,
                      :remote => true, :method => 'delete',
                      :class => "delete icon-only icon-link-break",
-                     :data => tooltip_stimulus_attributes(text: l(:button_remove)))
+                     **tooltip_options(l(:button_remove)))
       end
       content << content_tag('li', s, :class => "user-#{user.id}")
     end

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -1,0 +1,69 @@
+/**
+ * Redmine - project management software
+ * Copyright (C) 2006-  Jean-Philippe Lang
+ * This code is released under the GNU General Public License.
+ */
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    text: String
+  };
+
+  connect() {
+    this.tooltipElement = null;
+  }
+
+  disconnect() {
+    this.#remove();
+  }
+
+  show() {
+    if (this.tooltipElement) return;
+
+    const tip = document.createElement('div');
+    tip.className = 'tooltip-body';
+    tip.textContent = this.textValue;
+    document.body.appendChild(tip);
+    this.tooltipElement = tip;
+
+    this.#position();
+  }
+
+  hide() {
+    this.#remove();
+  }
+
+  #position() {
+    const tip = this.tooltipElement;
+    if (!tip) return;
+
+    const rect = this.element.getBoundingClientRect();
+    const tipRect = tip.getBoundingClientRect();
+
+    let top = rect.top - tipRect.height - 5;
+    let left = rect.left + rect.width / 2 - tipRect.width / 2;
+
+    // If tooltip goes above viewport, show below
+    if (top < 0) {
+      top = rect.bottom + 5;
+    }
+
+    // Keep within horizontal viewport bounds
+    if (left < 4) {
+      left = 4;
+    } else if (left + tipRect.width > window.innerWidth - 4) {
+      left = window.innerWidth - tipRect.width - 4;
+    }
+
+    tip.style.top = `${top + window.scrollY}px`;
+    tip.style.left = `${left + window.scrollX}px`;
+  }
+
+  #remove() {
+    if (this.tooltipElement) {
+      this.tooltipElement.remove();
+      this.tooltipElement = null;
+    }
+  }
+}

--- a/app/javascript/controllers/tooltip_controller.js
+++ b/app/javascript/controllers/tooltip_controller.js
@@ -5,40 +5,124 @@
  */
 import { Controller } from "@hotwired/stimulus"
 
+let tooltipId = 0;
+
 export default class extends Controller {
-  static values = {
-    text: String
-  };
+  static targets = ['trigger'];
+
+  initialize() {
+    this.show = this.show.bind(this);
+    this.hide = this.hide.bind(this);
+    this.handleKeyup = this.handleKeyup.bind(this);
+  }
 
   connect() {
     this.tooltipElement = null;
+    this.activeTrigger = null;
+    this.activeTitle = null;
+    this.showTimeout = null;
   }
 
   disconnect() {
-    this.#remove();
+    this.triggerTargets.forEach((element) => this.#stopListening(element));
+    this.hide();
   }
 
-  show() {
-    if (this.tooltipElement) return;
+  // Event listeners are managed here so that one application-wide controller
+  // can enhance title attributes while preserving them for non-JS renderers.
+  // This is specific to tooltips and is not a general controller pattern.
+  triggerTargetConnected(element) {
+    this.#startListening(element);
+  }
+
+  triggerTargetDisconnected(element) {
+    this.#stopListening(element);
+
+    if (element === this.activeTrigger) {
+      this.hide();
+    }
+  }
+
+  #startListening(element) {
+    element.addEventListener('mouseenter', this.show);
+    element.addEventListener('mouseleave', this.hide);
+    element.addEventListener('focusin', this.show);
+    element.addEventListener('focusout', this.hide);
+    element.addEventListener('keyup', this.handleKeyup);
+  }
+
+  #stopListening(element) {
+    element.removeEventListener('mouseenter', this.show);
+    element.removeEventListener('mouseleave', this.hide);
+    element.removeEventListener('focusin', this.show);
+    element.removeEventListener('focusout', this.hide);
+    element.removeEventListener('keyup', this.handleKeyup);
+  }
+
+  show(event) {
+    const trigger = event.currentTarget;
+    if (trigger === this.activeTrigger) return;
+
+    this.hide();
+
+    const title = trigger.getAttribute('title');
+    if (!title) return;
+
+    this.activeTrigger = trigger;
+    this.activeTitle = title;
+    trigger.removeAttribute('title');
+
+    this.showTimeout = window.setTimeout(() => {
+      this.showTimeout = null;
+      this.#create();
+    }, 400);
+  }
+
+  hide() {
+    if (this.showTimeout) {
+      window.clearTimeout(this.showTimeout);
+      this.showTimeout = null;
+    }
+
+    if (this.activeTrigger) {
+      if (this.activeTitle !== null && !this.activeTrigger.hasAttribute('title')) {
+        this.activeTrigger.setAttribute('title', this.activeTitle);
+      }
+      this.#removeDescribedBy(this.activeTrigger);
+    }
+
+    this.#remove();
+
+    this.activeTrigger = null;
+    this.activeTitle = null;
+  }
+
+  handleKeyup(event) {
+    if (event.key === 'Escape' && event.currentTarget === this.activeTrigger) {
+      this.hide();
+    }
+  }
+
+  #create() {
+    if (!this.activeTrigger || this.tooltipElement) return;
 
     const tip = document.createElement('div');
+    tip.id = `tooltip-${++tooltipId}`;
     tip.className = 'tooltip-body';
-    tip.textContent = this.textValue;
+    tip.setAttribute('role', 'tooltip');
+    tip.textContent = this.activeTitle;
     document.body.appendChild(tip);
     this.tooltipElement = tip;
+    this.#addDescribedBy(this.activeTrigger, tip.id);
 
     this.#position();
   }
 
-  hide() {
-    this.#remove();
-  }
-
   #position() {
     const tip = this.tooltipElement;
-    if (!tip) return;
+    if (!tip || !this.activeTrigger) return;
 
-    const rect = this.element.getBoundingClientRect();
+    const rect = this.activeTrigger.getBoundingClientRect();
     const tipRect = tip.getBoundingClientRect();
 
     let top = rect.top - tipRect.height - 5;
@@ -58,6 +142,24 @@ export default class extends Controller {
 
     tip.style.top = `${top + window.scrollY}px`;
     tip.style.left = `${left + window.scrollX}px`;
+  }
+
+  #addDescribedBy(trigger, id) {
+    const ids = (trigger.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+    ids.push(id);
+    trigger.setAttribute('aria-describedby', ids.join(' '));
+  }
+
+  #removeDescribedBy(trigger) {
+    if (!this.tooltipElement) return;
+
+    const ids = (trigger.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+    const remainingIds = ids.filter((id) => id !== this.tooltipElement.id);
+    if (remainingIds.length) {
+      trigger.setAttribute('aria-describedby', remainingIds.join(' '));
+    } else {
+      trigger.removeAttribute('aria-describedby');
+    }
   }
 
   #remove() {

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -10,12 +10,12 @@
     <li class="previous page">
 <%= link_to("\xc2\xab " + l(:label_previous),
                    {:params => request.query_parameters.merge(:from => @date_to - @days - 1)},
-                   :title => l(:label_date_from_to, :start => format_date(@date_to - 2*@days), :end => format_date(@date_to - @days - 1)),
+                   :data => tooltip_stimulus_attributes(text: l(:label_date_from_to, :start => format_date(@date_to - 2*@days), :end => format_date(@date_to - @days - 1))),
                    :accesskey => accesskey(:previous)) %>
     </li><% unless @date_to > User.current.today %><li class="next page">
 <%= link_to(l(:label_next) + " \xc2\xbb",
                    {:params => request.query_parameters.merge(:from => @date_to + @days - 1)},
-                   :title => l(:label_date_from_to, :start => format_date(@date_to), :end => format_date(@date_to + @days - 1)),
+                   :data => tooltip_stimulus_attributes(text: l(:label_date_from_to, :start => format_date(@date_to), :end => format_date(@date_to + @days - 1))),
                    :accesskey => accesskey(:next)) %></li><% end %>
   </ul>
 </span>

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -10,12 +10,12 @@
     <li class="previous page">
 <%= link_to("\xc2\xab " + l(:label_previous),
                    {:params => request.query_parameters.merge(:from => @date_to - @days - 1)},
-                   :data => tooltip_stimulus_attributes(text: l(:label_date_from_to, :start => format_date(@date_to - 2*@days), :end => format_date(@date_to - @days - 1))),
+                   **tooltip_options(l(:label_date_from_to, :start => format_date(@date_to - 2*@days), :end => format_date(@date_to - @days - 1))),
                    :accesskey => accesskey(:previous)) %>
     </li><% unless @date_to > User.current.today %><li class="next page">
 <%= link_to(l(:label_next) + " \xc2\xbb",
                    {:params => request.query_parameters.merge(:from => @date_to + @days - 1)},
-                   :data => tooltip_stimulus_attributes(text: l(:label_date_from_to, :start => format_date(@date_to), :end => format_date(@date_to + @days - 1))),
+                   **tooltip_options(l(:label_date_from_to, :start => format_date(@date_to), :end => format_date(@date_to + @days - 1))),
                    :accesskey => accesskey(:next)) %></li><% end %>
   </ul>
 </span>

--- a/app/views/attachments/_links.html.erb
+++ b/app/views/attachments/_links.html.erb
@@ -2,12 +2,12 @@
 <div class="contextual">
   <%= link_to(sprite_icon('edit', l(:label_edit_attachments)),
               container_attachments_edit_path(container),
-              :title => l(:label_edit_attachments),
+              :data => tooltip_stimulus_attributes(text: l(:label_edit_attachments)),
               :class => 'icon-only icon-edit '
              ) if options[:editable] %>
   <%= link_to(sprite_icon('download', l(:label_download_all_attachments)),
               container_attachments_download_path(container),
-              :title => l(:label_download_all_attachments),
+              :data => tooltip_stimulus_attributes(text: l(:label_download_all_attachments)),
               :class => 'icon-only icon-download '
              ) if attachments.size > 1 %>
 </div>
@@ -17,7 +17,7 @@
   <td>
     <%= link_to_attachment attachment, class: 'icon icon-attachment ', icon: icon_for_mime_type(attachment.content_type) -%>
     <span class="size">(<%= number_to_human_size attachment.filesize %>)</span>
-    <%= link_to_attachment attachment, class: 'icon-only icon-download ', title: l(:button_download), download: true, icon: 'download' -%>
+    <%= link_to_attachment attachment, class: 'icon-only icon-download ', data: tooltip_stimulus_attributes(text: l(:button_download)), download: true, icon: 'download' -%>
   </td>
   <td><%= attachment.description unless attachment.description.blank? %></td>
   <td>
@@ -28,10 +28,9 @@
   <td>
     <% if options[:deletable] %>
       <%= link_to sprite_icon('del', l(:button_delete)), attachment_path(attachment),
-                  :data => {:confirm => l(:text_are_you_sure)},
-                  :method => :delete,
-                  :class => 'delete icon-only icon-del ',
-                  :title => l(:button_delete) %>
+	                  :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
+	                  :method => :delete,
+	                  :class => 'delete icon-only icon-del ' %>
     <% end %>
   </td>
 </tr>

--- a/app/views/attachments/_links.html.erb
+++ b/app/views/attachments/_links.html.erb
@@ -2,12 +2,12 @@
 <div class="contextual">
   <%= link_to(sprite_icon('edit', l(:label_edit_attachments)),
               container_attachments_edit_path(container),
-              :data => tooltip_stimulus_attributes(text: l(:label_edit_attachments)),
+              **tooltip_options(l(:label_edit_attachments)),
               :class => 'icon-only icon-edit '
              ) if options[:editable] %>
   <%= link_to(sprite_icon('download', l(:label_download_all_attachments)),
               container_attachments_download_path(container),
-              :data => tooltip_stimulus_attributes(text: l(:label_download_all_attachments)),
+              **tooltip_options(l(:label_download_all_attachments)),
               :class => 'icon-only icon-download '
              ) if attachments.size > 1 %>
 </div>
@@ -17,7 +17,7 @@
   <td>
     <%= link_to_attachment attachment, class: 'icon icon-attachment ', icon: icon_for_mime_type(attachment.content_type) -%>
     <span class="size">(<%= number_to_human_size attachment.filesize %>)</span>
-    <%= link_to_attachment attachment, class: 'icon-only icon-download ', data: tooltip_stimulus_attributes(text: l(:button_download)), download: true, icon: 'download' -%>
+    <%= link_to_attachment attachment, class: 'icon-only icon-download ', **tooltip_options(l(:button_download)), download: true, icon: 'download' -%>
   </td>
   <td><%= attachment.description unless attachment.description.blank? %></td>
   <td>
@@ -28,7 +28,7 @@
   <td>
     <% if options[:deletable] %>
       <%= link_to sprite_icon('del', l(:button_delete)), attachment_path(attachment),
-	                  :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
+	                  **tooltip_options(l(:button_delete), :data => {:confirm => l(:text_are_you_sure)}),
 	                  :method => :delete,
 	                  :class => 'delete icon-only icon-del ' %>
     <% end %>

--- a/app/views/common/_calendar.html.erb
+++ b/app/views/common/_calendar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag({}, :data => {:cm_url => issues_context_menu_path}) do -%>
 <%= hidden_field_tag 'back_url', url_for(:params => request.query_parameters), :id => nil %>
 <ul class="cal">
-  <li scope="col" title="<%= l(:label_week) %>" class="calhead week-number"></li>
+  <li scope="col" class="calhead week-number" <%= tag.attributes(data: tooltip_stimulus_attributes(text: l(:label_week))) %>></li>
   <% 7.times do |i| %>
     <li scope="col" class="calhead"><%= day_name((calendar.first_wday + i) % 7) %></li>
   <% end %>

--- a/app/views/common/_calendar.html.erb
+++ b/app/views/common/_calendar.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag({}, :data => {:cm_url => issues_context_menu_path}) do -%>
 <%= hidden_field_tag 'back_url', url_for(:params => request.query_parameters), :id => nil %>
 <ul class="cal">
-  <li scope="col" class="calhead week-number" <%= tag.attributes(data: tooltip_stimulus_attributes(text: l(:label_week))) %>></li>
+  <li scope="col" class="calhead week-number" <%= tag.attributes(**tooltip_options(l(:label_week))) %>></li>
   <% 7.times do |i| %>
     <li scope="col" class="calhead"><%= day_name((calendar.first_wday + i) % 7) %></li>
   <% end %>

--- a/app/views/custom_field_enumerations/index.html.erb
+++ b/app/views/custom_field_enumerations/index.html.erb
@@ -6,7 +6,7 @@
   <ul id="custom_field_enumerations" class="flat">
   <% @custom_field.enumerations.each_with_index do |value, position| %>
     <li>
-      <%= tag.span(sprite_icon('reorder', ''), :class => 'icon-only icon-sort-handle sort-handle', :title => l(:button_move)) %>
+      <%= tag.span(sprite_icon('reorder', ''), :class => 'icon-only icon-sort-handle sort-handle', :data => tooltip_stimulus_attributes(text: l(:button_move))) %>
       <%= hidden_field_tag "custom_field_enumerations[#{value.id}][position]", position, :class => 'position' %>
       <%= text_field_tag "custom_field_enumerations[#{value.id}][name]", value.name, :size => 40 %>
       <%= hidden_field_tag "custom_field_enumerations[#{value.id}][active]", 0 %>

--- a/app/views/custom_field_enumerations/index.html.erb
+++ b/app/views/custom_field_enumerations/index.html.erb
@@ -6,7 +6,7 @@
   <ul id="custom_field_enumerations" class="flat">
   <% @custom_field.enumerations.each_with_index do |value, position| %>
     <li>
-      <%= tag.span(sprite_icon('reorder', ''), :class => 'icon-only icon-sort-handle sort-handle', :data => tooltip_stimulus_attributes(text: l(:button_move))) %>
+      <%= tag.span(sprite_icon('reorder', ''), :class => 'icon-only icon-sort-handle sort-handle', **tooltip_options(l(:button_move))) %>
       <%= hidden_field_tag "custom_field_enumerations[#{value.id}][position]", position, :class => 'position' %>
       <%= text_field_tag "custom_field_enumerations[#{value.id}][name]", value.name, :size => 40 %>
       <%= hidden_field_tag "custom_field_enumerations[#{value.id}][active]", 0 %>

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -28,13 +28,13 @@
     <% end -%>
     <% container.attachments.each do |file| %>
     <tr class="file">
-      <td class="filename"><%= link_to_attachment file, :title => file.description -%></td>
+      <td class="filename"><%= link_to_attachment file, :data => tooltip_stimulus_attributes(text: file.description) -%></td>
       <td class="created_on"><%= format_time(file.created_on) %></td>
       <td class="filesize"><%= number_to_human_size(file.filesize) %></td>
       <td class="downloads"><%= file.downloads %></td>
       <td class="digest"><%= file.digest_type %>: <%= file.digest %></td>
       <td class="buttons">
-      <%= link_to_attachment file, class: 'icon-only icon-download', title: l(:button_download), download: true, icon: 'download' %>
+      <%= link_to_attachment file, class: 'icon-only icon-download', data: tooltip_stimulus_attributes(text: l(:button_download)), download: true, icon: 'download' %>
       <%= link_to(sprite_icon('del', l(:button_delete)), attachment_path(file), :class => 'icon-only icon-del',
                   :data => {:confirm => l(:text_are_you_sure)}, :method => :delete) if delete_allowed %>
       </td>

--- a/app/views/files/index.html.erb
+++ b/app/views/files/index.html.erb
@@ -28,13 +28,13 @@
     <% end -%>
     <% container.attachments.each do |file| %>
     <tr class="file">
-      <td class="filename"><%= link_to_attachment file, :data => tooltip_stimulus_attributes(text: file.description) -%></td>
+      <td class="filename"><%= link_to_attachment file, **tooltip_options(file.description) -%></td>
       <td class="created_on"><%= format_time(file.created_on) %></td>
       <td class="filesize"><%= number_to_human_size(file.filesize) %></td>
       <td class="downloads"><%= file.downloads %></td>
       <td class="digest"><%= file.digest_type %>: <%= file.digest %></td>
       <td class="buttons">
-      <%= link_to_attachment file, class: 'icon-only icon-download', data: tooltip_stimulus_attributes(text: l(:button_download)), download: true, icon: 'download' %>
+      <%= link_to_attachment file, class: 'icon-only icon-download', **tooltip_options(l(:button_download)), download: true, icon: 'download' %>
       <%= link_to(sprite_icon('del', l(:button_delete)), attachment_path(file), :class => 'icon-only icon-del',
                   :data => {:confirm => l(:text_are_you_sure)}, :method => :delete) if delete_allowed %>
       </td>

--- a/app/views/gantts/_chart.html.erb
+++ b/app/views/gantts/_chart.html.erb
@@ -125,7 +125,7 @@
           <%= content_tag(:div, style: month_style, class: "gantt_hdr") do %>
             <%= link_to "#{month_f.year}-#{month_f.month}",
                         gantt.params.merge(year: month_f.year, month: month_f.month),
-                        title: "#{month_name(month_f.month)} #{month_f.year}" %>
+                        data: tooltip_stimulus_attributes(text: "#{month_name(month_f.month)} #{month_f.year}") %>
           <% end %>
           <% left += width + 1 %>
           <% month_f = month_f >> 1 %>

--- a/app/views/gantts/_chart.html.erb
+++ b/app/views/gantts/_chart.html.erb
@@ -125,7 +125,7 @@
           <%= content_tag(:div, style: month_style, class: "gantt_hdr") do %>
             <%= link_to "#{month_f.year}-#{month_f.month}",
                         gantt.params.merge(year: month_f.year, month: month_f.month),
-                        data: tooltip_stimulus_attributes(text: "#{month_name(month_f.month)} #{month_f.year}") %>
+                        **tooltip_options("#{month_name(month_f.month)} #{month_f.year}") %>
           <% end %>
           <% left += width + 1 %>
           <% month_f = month_f >> 1 %>

--- a/app/views/issues/_attributes.html.erb
+++ b/app/views/issues/_attributes.html.erb
@@ -6,10 +6,10 @@
 <p>
   <%= f.select :status_id, (@allowed_statuses.collect {|p| [p.name, p.id]}), {:required => true},
     :onchange => "updateIssueFrom('#{escape_javascript(update_issue_form_path(@project, @issue))}', this)",
-    :title => @issue.status.description %>
-  <%= content_tag 'a', sprite_icon('help', l(:label_open_issue_statuses_description)), :class => 'icon-only icon-help', :title => l(:label_open_issue_statuses_description), :onclick => "showModal('issue_statuses_description', '500px'); return false;", :href => '#' if @allowed_statuses.any? {|s| s.description.present? } %>
+    :data => tooltip_stimulus_attributes(text: @issue.status.description) %>
+  <%= content_tag 'a', sprite_icon('help', l(:label_open_issue_statuses_description)), :class => 'icon-only icon-help', :data => tooltip_stimulus_attributes(text: l(:label_open_issue_statuses_description)), :onclick => "showModal('issue_statuses_description', '500px'); return false;", :href => '#' if @allowed_statuses.any? {|s| s.description.present? } %>
   <% if @issue.transition_warning %>
-    <span class="icon-only icon-warning" title="<%= @issue.transition_warning %>"><%= sprite_icon('warning', l(:notice_issue_not_closable_by_open_tasks)) %></span>
+    <span class="icon-only icon-warning" <%= tag.attributes(data: tooltip_stimulus_attributes(text: @issue.transition_warning)) %>><%= sprite_icon('warning', l(:notice_issue_not_closable_by_open_tasks)) %></span>
   <% end %>
 </p>
 <%= render partial: 'issues/issue_status_description', locals: { issue_statuses: @allowed_statuses } %>
@@ -40,7 +40,7 @@
             new_project_issue_category_path(@issue.project),
             :remote => true,
             :method => 'get',
-            :title => l(:label_issue_category_new),
+            :data => tooltip_stimulus_attributes(text: l(:label_issue_category_new)),
             :tabindex => 200,
             :class => 'icon-only icon-add'
            ) if User.current.allowed_to?(:manage_categories, @issue.project) %></p>
@@ -53,7 +53,7 @@
             new_project_version_path(@issue.project),
             :remote => true,
             :method => 'get',
-            :title => l(:label_version_new),
+            :data => tooltip_stimulus_attributes(text: l(:label_version_new)),
             :tabindex => 200,
             :class => 'icon-only icon-add'
            ) if User.current.allowed_to?(:manage_versions, @issue.project) %>

--- a/app/views/issues/_attributes.html.erb
+++ b/app/views/issues/_attributes.html.erb
@@ -6,10 +6,10 @@
 <p>
   <%= f.select :status_id, (@allowed_statuses.collect {|p| [p.name, p.id]}), {:required => true},
     :onchange => "updateIssueFrom('#{escape_javascript(update_issue_form_path(@project, @issue))}', this)",
-    :data => tooltip_stimulus_attributes(text: @issue.status.description) %>
-  <%= content_tag 'a', sprite_icon('help', l(:label_open_issue_statuses_description)), :class => 'icon-only icon-help', :data => tooltip_stimulus_attributes(text: l(:label_open_issue_statuses_description)), :onclick => "showModal('issue_statuses_description', '500px'); return false;", :href => '#' if @allowed_statuses.any? {|s| s.description.present? } %>
+    **tooltip_options(@issue.status.description) %>
+  <%= content_tag 'a', sprite_icon('help', l(:label_open_issue_statuses_description)), :class => 'icon-only icon-help', **tooltip_options(l(:label_open_issue_statuses_description)), :onclick => "showModal('issue_statuses_description', '500px'); return false;", :href => '#' if @allowed_statuses.any? {|s| s.description.present? } %>
   <% if @issue.transition_warning %>
-    <span class="icon-only icon-warning" <%= tag.attributes(data: tooltip_stimulus_attributes(text: @issue.transition_warning)) %>><%= sprite_icon('warning', l(:notice_issue_not_closable_by_open_tasks)) %></span>
+    <span class="icon-only icon-warning" <%= tag.attributes(**tooltip_options(@issue.transition_warning)) %>><%= sprite_icon('warning', l(:notice_issue_not_closable_by_open_tasks)) %></span>
   <% end %>
 </p>
 <%= render partial: 'issues/issue_status_description', locals: { issue_statuses: @allowed_statuses } %>
@@ -40,7 +40,7 @@
             new_project_issue_category_path(@issue.project),
             :remote => true,
             :method => 'get',
-            :data => tooltip_stimulus_attributes(text: l(:label_issue_category_new)),
+            **tooltip_options(l(:label_issue_category_new)),
             :tabindex => 200,
             :class => 'icon-only icon-add'
            ) if User.current.allowed_to?(:manage_categories, @issue.project) %></p>
@@ -53,7 +53,7 @@
             new_project_version_path(@issue.project),
             :remote => true,
             :method => 'get',
-            :data => tooltip_stimulus_attributes(text: l(:label_version_new)),
+            **tooltip_options(l(:label_version_new)),
             :tabindex => 200,
             :class => 'icon-only icon-add'
            ) if User.current.allowed_to?(:manage_versions, @issue.project) %>

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -19,8 +19,8 @@
 <p>
   <%= f.select :tracker_id, trackers_options_for_select(@issue), {:required => true},
                :onchange => "updateIssueFrom('#{escape_javascript update_issue_form_path(@project, @issue)}', this)",
-               :title => @issue.tracker.description %>
-  <%= content_tag 'a', sprite_icon('help', l(:label_open_trackers_description)), :class => 'icon-only icon-help', :title => l(:label_open_trackers_description), :onclick => "showModal('trackers_description', '500px'); return false;", :href => '#' if trackers_for_select(@issue).any? {|t| t.description.present? } %>
+               :data => tooltip_stimulus_attributes(text: @issue.tracker.description) %>
+  <%= content_tag 'a', sprite_icon('help', l(:label_open_trackers_description)), :class => 'icon-only icon-help', :data => tooltip_stimulus_attributes(text: l(:label_open_trackers_description)), :onclick => "showModal('trackers_description', '500px'); return false;", :href => '#' if trackers_for_select(@issue).any? {|t| t.description.present? } %>
 </p>
   <%= render partial: 'issues/trackers_description', locals: {trackers: trackers_for_select(@issue)} %>
 <% end %>

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -19,8 +19,8 @@
 <p>
   <%= f.select :tracker_id, trackers_options_for_select(@issue), {:required => true},
                :onchange => "updateIssueFrom('#{escape_javascript update_issue_form_path(@project, @issue)}', this)",
-               :data => tooltip_stimulus_attributes(text: @issue.tracker.description) %>
-  <%= content_tag 'a', sprite_icon('help', l(:label_open_trackers_description)), :class => 'icon-only icon-help', :data => tooltip_stimulus_attributes(text: l(:label_open_trackers_description)), :onclick => "showModal('trackers_description', '500px'); return false;", :href => '#' if trackers_for_select(@issue).any? {|t| t.description.present? } %>
+               **tooltip_options(@issue.tracker.description) %>
+  <%= content_tag 'a', sprite_icon('help', l(:label_open_trackers_description)), :class => 'icon-only icon-help', **tooltip_options(l(:label_open_trackers_description)), :onclick => "showModal('trackers_description', '500px'); return false;", :href => '#' if trackers_for_select(@issue).any? {|t| t.description.present? } %>
 </p>
   <%= render partial: 'issues/trackers_description', locals: {trackers: trackers_for_select(@issue)} %>
 <% end %>

--- a/app/views/issues/_issue_status_description.html.erb
+++ b/app/views/issues/_issue_status_description.html.erb
@@ -4,7 +4,7 @@
       <dl>
       <% issue_statuses.each do |issue_status| %>
         <% if issue_status.description.present? %>
-          <dt><%= content_tag 'a', issue_status.name, :onclick => "selectIssueStatus('#{issue_status.id}'); return false;", :href => '#', :title => l(:text_select_apply_issue_status) %></dt>
+          <dt><%= content_tag 'a', issue_status.name, :onclick => "selectIssueStatus('#{issue_status.id}'); return false;", :href => '#', :data => tooltip_stimulus_attributes(text: l(:text_select_apply_issue_status)) %></dt>
           <dd><%= issue_status.description %></dd>
         <% end %>
       <% end %>

--- a/app/views/issues/_issue_status_description.html.erb
+++ b/app/views/issues/_issue_status_description.html.erb
@@ -4,7 +4,7 @@
       <dl>
       <% issue_statuses.each do |issue_status| %>
         <% if issue_status.description.present? %>
-          <dt><%= content_tag 'a', issue_status.name, :onclick => "selectIssueStatus('#{issue_status.id}'); return false;", :href => '#', :data => tooltip_stimulus_attributes(text: l(:text_select_apply_issue_status)) %></dt>
+          <dt><%= content_tag 'a', issue_status.name, :onclick => "selectIssueStatus('#{issue_status.id}'); return false;", :href => '#', **tooltip_options(l(:text_select_apply_issue_status)) %></dt>
           <dd><%= issue_status.description %></dd>
         <% end %>
       <% end %>

--- a/app/views/issues/_list.html.erb
+++ b/app/views/issues/_list.html.erb
@@ -10,7 +10,7 @@
     <tr>
       <th class="checkbox hide-when-print">
         <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-              :title => "#{l(:button_check_all)} / #{l(:button_uncheck_all)}" %>
+              :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
       </th>
       <% query.inline_columns.each do |column| %>
         <%= column_header(query, column, query_options) %>

--- a/app/views/issues/_list.html.erb
+++ b/app/views/issues/_list.html.erb
@@ -10,7 +10,7 @@
     <tr>
       <th class="checkbox hide-when-print">
         <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-              :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
+              **tooltip_options("#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
       </th>
       <% query.inline_columns.each do |column| %>
         <%= column_header(query, column, query_options) %>

--- a/app/views/issues/_trackers_description.html.erb
+++ b/app/views/issues/_trackers_description.html.erb
@@ -4,7 +4,7 @@
       <dl>
       <% trackers.each do |tracker| %>
         <% if tracker.description.present? %>
-          <dt><%= content_tag 'a', tracker.name, :onclick => "selectTracker('#{tracker.id}'); return false;", :href => '#', :title => l(:text_select_apply_tracker) %></dt>
+          <dt><%= content_tag 'a', tracker.name, :onclick => "selectTracker('#{tracker.id}'); return false;", :href => '#', :data => tooltip_stimulus_attributes(text: l(:text_select_apply_tracker)) %></dt>
           <dd><%= tracker.description %></dd>
         <% end %>
       <% end %>

--- a/app/views/issues/_trackers_description.html.erb
+++ b/app/views/issues/_trackers_description.html.erb
@@ -4,7 +4,7 @@
       <dl>
       <% trackers.each do |tracker| %>
         <% if tracker.description.present? %>
-          <dt><%= content_tag 'a', tracker.name, :onclick => "selectTracker('#{tracker.id}'); return false;", :href => '#', :data => tooltip_stimulus_attributes(text: l(:text_select_apply_tracker)) %></dt>
+          <dt><%= content_tag 'a', tracker.name, :onclick => "selectTracker('#{tracker.id}'); return false;", :href => '#', **tooltip_options(l(:text_select_apply_tracker)) %></dt>
           <dd><%= tracker.description %></dd>
         <% end %>
       <% end %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -14,7 +14,7 @@
             <% if @prev_issue_id %>
               <%= link_to "\xc2\xab #{l(:label_previous)}",
                           issue_path(@prev_issue_id),
-                          :title => "##{@prev_issue_id}",
+                          :data => tooltip_stimulus_attributes(text: "##{@prev_issue_id}"),
                           :accesskey => accesskey(:previous) %>
             <% else %>
               <%= content_tag(:span, "\xc2\xab #{l(:label_previous)}") %>
@@ -34,7 +34,7 @@
             <% if @next_issue_id %>
               <%= link_to "#{l(:label_next)} \xc2\xbb",
                           issue_path(@next_issue_id),
-                          :title => "##{@next_issue_id}",
+                          :data => tooltip_stimulus_attributes(text: "##{@next_issue_id}"),
                           :accesskey => accesskey(:next) %>
             <% else %>
               <%= content_tag(:span, "#{l(:label_next)} \xc2\xbb") %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -14,7 +14,7 @@
             <% if @prev_issue_id %>
               <%= link_to "\xc2\xab #{l(:label_previous)}",
                           issue_path(@prev_issue_id),
-                          :data => tooltip_stimulus_attributes(text: "##{@prev_issue_id}"),
+                          **tooltip_options("##{@prev_issue_id}"),
                           :accesskey => accesskey(:previous) %>
             <% else %>
               <%= content_tag(:span, "\xc2\xab #{l(:label_previous)}") %>
@@ -34,7 +34,7 @@
             <% if @next_issue_id %>
               <%= link_to "#{l(:label_next)} \xc2\xbb",
                           issue_path(@next_issue_id),
-                          :data => tooltip_stimulus_attributes(text: "##{@next_issue_id}"),
+                          **tooltip_options("##{@next_issue_id}"),
                           :accesskey => accesskey(:next) %>
             <% else %>
               <%= content_tag(:span, "#{l(:label_next)} \xc2\xbb") %>

--- a/app/views/issues/tabs/_time_entries.html.erb
+++ b/app/views/issues/tabs/_time_entries.html.erb
@@ -8,12 +8,11 @@
       <% if time_entry.editable_by?(User.current) -%>
           <span class="journal-meta">
             <%= link_to sprite_icon('edit', l(:button_edit)), edit_time_entry_path(time_entry),
-                        :title => l(:button_edit),
+                        :data => tooltip_stimulus_attributes(text: l(:button_edit)),
                         :class => 'icon-only icon-edit' %>
             <%= link_to sprite_icon('del', l(:button_delete)), time_entry_path(time_entry),
-                        :data => { :confirm => l(:text_are_you_sure) },
+                        :data => { :confirm => l(:text_are_you_sure) }.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
                         :method => :delete,
-                        :title => l(:button_delete),
                         :class => 'icon-only icon-del' %>
           </span>
       <% end -%>

--- a/app/views/issues/tabs/_time_entries.html.erb
+++ b/app/views/issues/tabs/_time_entries.html.erb
@@ -8,10 +8,10 @@
       <% if time_entry.editable_by?(User.current) -%>
           <span class="journal-meta">
             <%= link_to sprite_icon('edit', l(:button_edit)), edit_time_entry_path(time_entry),
-                        :data => tooltip_stimulus_attributes(text: l(:button_edit)),
+                        **tooltip_options(l(:button_edit)),
                         :class => 'icon-only icon-edit' %>
             <%= link_to sprite_icon('del', l(:button_delete)), time_entry_path(time_entry),
-                        :data => { :confirm => l(:text_are_you_sure) }.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
+                        **tooltip_options(l(:button_delete), :data => { :confirm => l(:text_are_you_sure) }),
                         :method => :delete,
                         :class => 'icon-only icon-del' %>
           </span>

--- a/app/views/journals/update.js.erb
+++ b/app/views/journals/update.js.erb
@@ -14,7 +14,6 @@
   } else {
     journal_header.append('<%= escape_javascript(render_journal_update_info(@journal)) %>');
   }
-  setupHoverTooltips();
 <% end %>
 
 <%= call_hook(:view_journals_update_js_bottom, { :journal => @journal }) %>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -18,7 +18,7 @@
 <!-- page specific tags -->
 <%= yield :header_tags -%>
 </head>
-<body class="<%= body_css_classes %>" data-text-formatting="<%= Setting.text_formatting %>">
+<body class="<%= body_css_classes %>" data-controller="tooltip" data-text-formatting="<%= Setting.text_formatting %>">
 <%= call_hook :view_layouts_base_body_top %>
 <div id="wrapper">
 

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -60,15 +60,14 @@
             <%= link_to(
                   sprite_icon('edit', l(:button_edit), icon_only: true),
                   { :action => 'edit', :id => message },
-                  :title => l(:button_edit),
+                  :data => tooltip_stimulus_attributes(text: l(:button_edit)),
                   :class => 'icon icon-edit'
                 ) if message.editable_by?(User.current) %>
             <%= link_to(
                   sprite_icon('del', l(:button_delete), icon_only: true),
                   { :action => 'destroy', :id => message },
                   :method => :post,
-                  :data => { :confirm => l(:text_are_you_sure) },
-                  :title => l(:button_delete),
+                  :data => { :confirm => l(:text_are_you_sure) }.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
                   :class => 'icon icon-del'
                 ) if message.destroyable_by?(User.current) %>
           </span>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -60,14 +60,14 @@
             <%= link_to(
                   sprite_icon('edit', l(:button_edit), icon_only: true),
                   { :action => 'edit', :id => message },
-                  :data => tooltip_stimulus_attributes(text: l(:button_edit)),
+                  **tooltip_options(l(:button_edit)),
                   :class => 'icon icon-edit'
                 ) if message.editable_by?(User.current) %>
             <%= link_to(
                   sprite_icon('del', l(:button_delete), icon_only: true),
                   { :action => 'destroy', :id => message },
                   :method => :post,
-                  :data => { :confirm => l(:text_are_you_sure) }.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
+                  **tooltip_options(l(:button_delete), :data => { :confirm => l(:text_are_you_sure) }),
                   :class => 'icon icon-del'
                 ) if message.destroyable_by?(User.current) %>
           </span>

--- a/app/views/my/_sidebar.html.erb
+++ b/app/views/my/_sidebar.html.erb
@@ -29,13 +29,14 @@
   <div class="api-key-actions">
     <%= link_to l(:button_show), my_api_key_path, :remote => true %>
     <a class="copy-api-key-link icon icon-only"
-       title="<%= l(:button_copy) %>"
        aria-label="<%= l(:button_copy) %>"
        href="#"
        role="button"
        tabindex="0"
        style="display: none;"
-       data-action="click->api-key-copy#copy">
+       data-action="click->api-key-copy#copy mouseenter->tooltip#show mouseleave->tooltip#hide"
+       data-controller="tooltip"
+       data-tooltip-text-value="<%= l(:button_copy) %>">
       <%= sprite_icon('copy') %>
     </a>
   </div>

--- a/app/views/my/_sidebar.html.erb
+++ b/app/views/my/_sidebar.html.erb
@@ -34,9 +34,9 @@
        role="button"
        tabindex="0"
        style="display: none;"
-       data-action="click->api-key-copy#copy mouseenter->tooltip#show mouseleave->tooltip#hide"
-       data-controller="tooltip"
-       data-tooltip-text-value="<%= l(:button_copy) %>">
+       data-action="click->api-key-copy#copy"
+       data-tooltip-target="trigger"
+       title="<%= l(:button_copy) %>">
       <%= sprite_icon('copy') %>
     </a>
   </div>

--- a/app/views/my/blocks/_issues.erb
+++ b/app/views/my/blocks/_issues.erb
@@ -1,5 +1,5 @@
 <div class="contextual">
-  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('##{block}-settings').toggle();", :class => 'icon-only icon-settings', :title => l(:label_options) %>
+  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('##{block}-settings').toggle();", :class => 'icon-only icon-settings', :data => tooltip_stimulus_attributes(text: l(:label_options)) %>
 </div>
 
 <h3>

--- a/app/views/my/blocks/_issues.erb
+++ b/app/views/my/blocks/_issues.erb
@@ -1,5 +1,5 @@
 <div class="contextual">
-  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('##{block}-settings').toggle();", :class => 'icon-only icon-settings', :data => tooltip_stimulus_attributes(text: l(:label_options)) %>
+  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('##{block}-settings').toggle();", :class => 'icon-only icon-settings', **tooltip_options(l(:label_options)) %>
 </div>
 
 <h3>

--- a/app/views/my/blocks/_timelog.html.erb
+++ b/app/views/my/blocks/_timelog.html.erb
@@ -1,11 +1,11 @@
 <div class="contextual">
-  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('#timelog-settings').toggle();", :class => 'icon-only icon-settings', :title => l(:label_options) %>
+  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('#timelog-settings').toggle();", :class => 'icon-only icon-settings', :data => tooltip_stimulus_attributes(text: l(:label_options)) %>
 </div>
 
 <h3>
   <%= link_to l(:label_spent_time), time_entries_path(:user_id => 'me') %>
   (<%= l(:label_last_n_days, days) %>: <%= l_hours_short entries.sum(&:hours) %>)
-  <%= link_to sprite_icon('time-add', l(:button_log_time)), new_time_entry_path, :class => "icon-only icon-add", :title => l(:button_log_time) if User.current.allowed_to?(:log_time, nil, :global => true) %>
+  <%= link_to sprite_icon('time-add', l(:button_log_time)), new_time_entry_path, :class => "icon-only icon-add", :data => tooltip_stimulus_attributes(text: l(:button_log_time)) if User.current.allowed_to?(:log_time, nil, :global => true) %>
 </h3>
 
 

--- a/app/views/my/blocks/_timelog.html.erb
+++ b/app/views/my/blocks/_timelog.html.erb
@@ -1,11 +1,11 @@
 <div class="contextual">
-  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('#timelog-settings').toggle();", :class => 'icon-only icon-settings', :data => tooltip_stimulus_attributes(text: l(:label_options)) %>
+  <%= link_to_function sprite_icon('settings', l(:label_options)), "$('#timelog-settings').toggle();", :class => 'icon-only icon-settings', **tooltip_options(l(:label_options)) %>
 </div>
 
 <h3>
   <%= link_to l(:label_spent_time), time_entries_path(:user_id => 'me') %>
   (<%= l(:label_last_n_days, days) %>: <%= l_hours_short entries.sum(&:hours) %>)
-  <%= link_to sprite_icon('time-add', l(:button_log_time)), new_time_entry_path, :class => "icon-only icon-add", :data => tooltip_stimulus_attributes(text: l(:button_log_time)) if User.current.allowed_to?(:log_time, nil, :global => true) %>
+  <%= link_to sprite_icon('time-add', l(:button_log_time)), new_time_entry_path, :class => "icon-only icon-add", **tooltip_options(l(:button_log_time)) if User.current.allowed_to?(:log_time, nil, :global => true) %>
 </h3>
 
 

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -51,8 +51,8 @@
         <span class="journal-meta">
           <%= reaction_button comment %>
           <%= link_to_if_authorized sprite_icon('del', l(:button_delete)), { :controller => 'comments', :action => 'destroy', :id => @news, :comment_id => comment},
-                                    :data => {:confirm => l(:text_are_you_sure)}, :method => :delete,
-                                    :title => l(:button_delete),
+                                    :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
+                                    :method => :delete,
                                     :class => 'icon-only icon-del' %>
         </span>
       </h4>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -51,7 +51,7 @@
         <span class="journal-meta">
           <%= reaction_button comment %>
           <%= link_to_if_authorized sprite_icon('del', l(:button_delete)), { :controller => 'comments', :action => 'destroy', :id => @news, :comment_id => comment},
-                                    :data => {:confirm => l(:text_are_you_sure)}.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
+                                    **tooltip_options(l(:button_delete), :data => {:confirm => l(:text_are_you_sure)}),
                                     :method => :delete,
                                     :class => 'icon-only icon-del' %>
         </span>

--- a/app/views/projects/_list.html.erb
+++ b/app/views/projects/_list.html.erb
@@ -8,8 +8,8 @@
   <tr>
     <% if @admin_list %>
       <th class="checkbox hide-when-print">
-        <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-          :title => "#{l(:button_check_all)} / #{l(:button_uncheck_all)}" %>
+      <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
+          :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
       </th>
     <% end %>
     <% @query.inline_columns.each do |column| %>

--- a/app/views/projects/_list.html.erb
+++ b/app/views/projects/_list.html.erb
@@ -9,7 +9,7 @@
     <% if @admin_list %>
       <th class="checkbox hide-when-print">
       <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-          :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
+          **tooltip_options("#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
       </th>
     <% end %>
     <% @query.inline_columns.each do |column| %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -48,7 +48,7 @@
       <%= link_to sprite_icon('zoom-in', l(:label_details)),
                   project_issues_report_details_path(@project, :detail => 'tracker'),
                   :class => 'icon-only icon-zoom-in',
-                  :title => l(:label_details) %>
+                  :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
     </h3>
     <% if @trackers.present? %>
     <table class="list issue-report">
@@ -64,7 +64,7 @@
       <% @trackers.each do |tracker| %>
         <tr>
           <td class="name">
-            <%= link_to tracker.name, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id), :title => tracker.description %>
+            <%= link_to tracker.name, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id), :data => tooltip_stimulus_attributes(text: tracker.description) %>
           </td>
           <td>
             <%= link_to @open_issues_by_tracker[tracker].to_i, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id) %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -48,7 +48,7 @@
       <%= link_to sprite_icon('zoom-in', l(:label_details)),
                   project_issues_report_details_path(@project, :detail => 'tracker'),
                   :class => 'icon-only icon-zoom-in',
-                  :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+                  **tooltip_options(l(:label_details)) %>
     </h3>
     <% if @trackers.present? %>
     <table class="list issue-report">
@@ -64,7 +64,7 @@
       <% @trackers.each do |tracker| %>
         <tr>
           <td class="name">
-            <%= link_to tracker.name, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id), :data => tooltip_stimulus_attributes(text: tracker.description) %>
+            <%= link_to tracker.name, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id), **tooltip_options(tracker.description) %>
           </td>
           <td>
             <%= link_to @open_issues_by_tracker[tracker].to_i, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id) %>

--- a/app/views/reactions/_replace_button.js.erb
+++ b/app/views/reactions/_replace_button.js.erb
@@ -1,7 +1,5 @@
 (() => {
   const button = $('[data-reaction-button-id=<%= reaction_id_for @object %>]');
 
-  removeHoverTooltips(button);
   button.html($('<%=j reaction_button @object %>').children());
-  setupHoverTooltips(button);
 })();

--- a/app/views/reports/issue_report.html.erb
+++ b/app/views/reports/issue_report.html.erb
@@ -7,7 +7,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'tracker'),
               :class => 'icon-only icon-zoom-in',
-              :title => l(:label_details) %>
+              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_tracker, :field_name => "tracker_id", :rows => @trackers } %>
 <br />
@@ -16,7 +16,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'priority'),
               :class => 'icon-only icon-zoom-in',
-              :title => l(:label_details) %>
+              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_priority, :field_name => "priority_id", :rows => @priorities } %>
 <br />
@@ -25,7 +25,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'assigned_to'),
               :class => 'icon-only icon-zoom-in',
-              :title => l(:label_details) %>
+              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_assigned_to, :field_name => "assigned_to_id", :rows => @assignees } %>
 <br />
@@ -34,7 +34,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'author'),
               :class => 'icon-only icon-zoom-in',
-              :title => l(:label_details) %>
+              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_author, :field_name => "author_id", :rows => @authors } %>
 <br />
@@ -47,7 +47,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'version'),
               :class => 'icon-only icon-zoom-in',
-              :title => l(:label_details) %>
+              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_version, :field_name => "fixed_version_id", :rows => @versions } %>
 <br />
@@ -57,7 +57,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'subproject'),
               :class => 'icon-only icon-zoom-in',
-              :title => l(:label_details) %>
+              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_subproject, :field_name => "project_id", :rows => @subprojects } %>
 <br />
@@ -67,7 +67,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'category'),
               :class => 'icon-only icon-zoom-in',
-              :title => l(:label_details) %>
+              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_category, :field_name => "category_id", :rows => @categories } %>
 <br />

--- a/app/views/reports/issue_report.html.erb
+++ b/app/views/reports/issue_report.html.erb
@@ -7,7 +7,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'tracker'),
               :class => 'icon-only icon-zoom-in',
-              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+              **tooltip_options(l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_tracker, :field_name => "tracker_id", :rows => @trackers } %>
 <br />
@@ -16,7 +16,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'priority'),
               :class => 'icon-only icon-zoom-in',
-              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+              **tooltip_options(l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_priority, :field_name => "priority_id", :rows => @priorities } %>
 <br />
@@ -25,7 +25,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'assigned_to'),
               :class => 'icon-only icon-zoom-in',
-              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+              **tooltip_options(l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_assigned_to, :field_name => "assigned_to_id", :rows => @assignees } %>
 <br />
@@ -34,7 +34,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'author'),
               :class => 'icon-only icon-zoom-in',
-              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+              **tooltip_options(l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_author, :field_name => "author_id", :rows => @authors } %>
 <br />
@@ -47,7 +47,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'version'),
               :class => 'icon-only icon-zoom-in',
-              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+              **tooltip_options(l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_version, :field_name => "fixed_version_id", :rows => @versions } %>
 <br />
@@ -57,7 +57,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'subproject'),
               :class => 'icon-only icon-zoom-in',
-              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+              **tooltip_options(l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_subproject, :field_name => "project_id", :rows => @subprojects } %>
 <br />
@@ -67,7 +67,7 @@
   <%= link_to sprite_icon('zoom-in', l(:label_details)),
               project_issues_report_details_path(@project, :detail => 'category'),
               :class => 'icon-only icon-zoom-in',
-              :data => tooltip_stimulus_attributes(text: l(:label_details)) %>
+              **tooltip_options(l(:label_details)) %>
 </h3>
 <%= render :partial => 'simple', :locals => { :data => @issues_by_category, :field_name => "category_id", :rows => @categories } %>
 <br />

--- a/app/views/repositories/_related_issues.html.erb
+++ b/app/views/repositories/_related_issues.html.erb
@@ -17,8 +17,9 @@
                   :rev => @changeset.identifier, :issue_id => issue},
                 :remote => true,
                 :method => :delete,
-                :data => {:confirm => l(:text_are_you_sure)},
-                :title => l(:label_relation_remove),
+                :data => {
+                  :confirm => l(:text_are_you_sure)
+                }.merge(tooltip_stimulus_attributes(text: l(:label_relation_remove))),
                 :class => 'icon-only icon-link-break'
                ) if manage_allowed %>
   </li>

--- a/app/views/repositories/_related_issues.html.erb
+++ b/app/views/repositories/_related_issues.html.erb
@@ -17,9 +17,10 @@
                   :rev => @changeset.identifier, :issue_id => issue},
                 :remote => true,
                 :method => :delete,
-                :data => {
-                  :confirm => l(:text_are_you_sure)
-                }.merge(tooltip_stimulus_attributes(text: l(:label_relation_remove))),
+                **tooltip_options(
+                  l(:label_relation_remove),
+                  :data => {:confirm => l(:text_are_you_sure)}
+                ),
                 :class => 'icon-only icon-link-break'
                ) if manage_allowed %>
   </li>

--- a/app/views/repositories/annotate.html.erb
+++ b/app/views/repositories/annotate.html.erb
@@ -35,7 +35,7 @@
         <% if @has_previous %>
         <td class="previous">
           <% if previous_annot && revision && revision != previous_revision %>
-            <%= link_to '', {:action => 'annotate', :id => @project, :repository_id => @repository.identifier_param, :path => to_path_param(previous_annot.split[1] || @path), :rev => previous_annot.split[0] }, :title => l(:label_view_previous_annotation), :class => 'icon icon-history' %>
+            <%= link_to '', {:action => 'annotate', :id => @project, :repository_id => @repository.identifier_param, :path => to_path_param(previous_annot.split[1] || @path), :rev => previous_annot.split[0] }, :data => tooltip_stimulus_attributes(text: l(:label_view_previous_annotation)), :class => 'icon icon-history' %>
           <% end %>
         </td>
         <% end %>

--- a/app/views/repositories/annotate.html.erb
+++ b/app/views/repositories/annotate.html.erb
@@ -35,7 +35,7 @@
         <% if @has_previous %>
         <td class="previous">
           <% if previous_annot && revision && revision != previous_revision %>
-            <%= link_to '', {:action => 'annotate', :id => @project, :repository_id => @repository.identifier_param, :path => to_path_param(previous_annot.split[1] || @path), :rev => previous_annot.split[0] }, :data => tooltip_stimulus_attributes(text: l(:label_view_previous_annotation)), :class => 'icon icon-history' %>
+            <%= link_to '', {:action => 'annotate', :id => @project, :repository_id => @repository.identifier_param, :path => to_path_param(previous_annot.split[1] || @path), :rev => previous_annot.split[0] }, **tooltip_options(l(:label_view_previous_annotation)), :class => 'icon icon-history' %>
           <% end %>
         </td>
         <% end %>

--- a/app/views/roles/permissions.html.erb
+++ b/app/views/roles/permissions.html.erb
@@ -66,7 +66,7 @@
         </td>
         <% @roles.each do |role| %>
           <% if role.setable_permissions.include? permission %>
-            <td title="<%= "#{humanized_perm_name} (#{role.name})" %>">
+            <td <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{humanized_perm_name} (#{role.name})")) %>>
               <%= check_box_tag "permissions[#{role.id}][]", permission.name, (role.permissions.include? permission.name), :id => nil, :class => "role-#{role.id}" %>
             </td>
           <% else %>

--- a/app/views/roles/permissions.html.erb
+++ b/app/views/roles/permissions.html.erb
@@ -66,7 +66,7 @@
         </td>
         <% @roles.each do |role| %>
           <% if role.setable_permissions.include? permission %>
-            <td <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{humanized_perm_name} (#{role.name})")) %>>
+            <td <%= tag.attributes(**tooltip_options("#{humanized_perm_name} (#{role.name})")) %>>
               <%= check_box_tag "permissions[#{role.id}][]", permission.name, (role.permissions.include? permission.name), :id => nil, :class => "role-#{role.id}" %>
             </td>
           <% else %>

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -122,7 +122,7 @@
       <td class="buttons">
         <%= link_to(sprite_icon('del', l(:button_delete)), '#',
                     :class => 'delete-commit-keywords icon-only icon-del',
-                    :title => l(:button_delete)) %>
+                    :data => tooltip_stimulus_attributes(text: l(:button_delete))) %>
       </td>
     </tr>
     <% end %>
@@ -134,7 +134,7 @@
       <td class="buttons">
         <%= link_to(sprite_icon('add', l(:button_add)), '#',
                     :class => 'add-commit-keywords icon-only icon-add',
-                    :title => l(:button_add)) %>
+                    :data => tooltip_stimulus_attributes(text: l(:button_add))) %>
       </td>
     </tr>
   </tbody>

--- a/app/views/settings/_repositories.html.erb
+++ b/app/views/settings/_repositories.html.erb
@@ -122,7 +122,7 @@
       <td class="buttons">
         <%= link_to(sprite_icon('del', l(:button_delete)), '#',
                     :class => 'delete-commit-keywords icon-only icon-del',
-                    :data => tooltip_stimulus_attributes(text: l(:button_delete))) %>
+                    **tooltip_options(l(:button_delete))) %>
       </td>
     </tr>
     <% end %>
@@ -134,7 +134,7 @@
       <td class="buttons">
         <%= link_to(sprite_icon('add', l(:button_add)), '#',
                     :class => 'add-commit-keywords icon-only icon-add',
-                    :data => tooltip_stimulus_attributes(text: l(:button_add))) %>
+                    **tooltip_options(l(:button_add))) %>
       </td>
     </tr>
   </tbody>

--- a/app/views/timelog/_list.html.erb
+++ b/app/views/timelog/_list.html.erb
@@ -6,7 +6,7 @@
   <tr>
     <th class="checkbox hide-when-print">
       <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-        :title => "#{l(:button_check_all)} / #{l(:button_uncheck_all)}" %>
+        :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
     </th>
     <% @query.inline_columns.each do |column| %>
       <%= column_header(@query, column) %>
@@ -39,12 +39,13 @@
     <td class="buttons hide-when-print">
     <% if entry.editable_by?(User.current) -%>
         <%= link_to sprite_icon('edit', l(:button_edit)), edit_time_entry_path(entry),
-                    :title => l(:button_edit),
+                    :data => tooltip_stimulus_attributes(text: l(:button_edit)),
                     :class => 'icon-only icon-edit' %>
         <%= link_to sprite_icon('del', l(:button_delete)), time_entry_path(entry),
-                    :data => {:confirm => l(:text_are_you_sure)},
+                    :data => {
+                      :confirm => l(:text_are_you_sure)
+                    }.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
                     :method => :delete,
-                    :title => l(:button_delete),
                     :class => 'icon-only icon-del' %>
     <% end -%>
         <%= link_to_context_menu %>

--- a/app/views/timelog/_list.html.erb
+++ b/app/views/timelog/_list.html.erb
@@ -6,7 +6,7 @@
   <tr>
     <th class="checkbox hide-when-print">
       <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-        :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
+        **tooltip_options("#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
     </th>
     <% @query.inline_columns.each do |column| %>
       <%= column_header(@query, column) %>
@@ -39,12 +39,10 @@
     <td class="buttons hide-when-print">
     <% if entry.editable_by?(User.current) -%>
         <%= link_to sprite_icon('edit', l(:button_edit)), edit_time_entry_path(entry),
-                    :data => tooltip_stimulus_attributes(text: l(:button_edit)),
+                    **tooltip_options(l(:button_edit)),
                     :class => 'icon-only icon-edit' %>
         <%= link_to sprite_icon('del', l(:button_delete)), time_entry_path(entry),
-                    :data => {
-                      :confirm => l(:text_are_you_sure)
-                    }.merge(tooltip_stimulus_attributes(text: l(:button_delete))),
+                    **tooltip_options(l(:button_delete), :data => {:confirm => l(:text_are_you_sure)}),
                     :method => :delete,
                     :class => 'icon-only icon-del' %>
     <% end -%>

--- a/app/views/trackers/fields.html.erb
+++ b/app/views/trackers/fields.html.erb
@@ -30,7 +30,7 @@
           <%= field_name %>
         </td>
         <% @trackers.each do |tracker| %>
-        <td title="<%= "#{tracker.name}: #{field_name}" %>">
+        <td <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{tracker.name}: #{field_name}")) %>>
           <%= check_box_tag "trackers[#{tracker.id}][core_fields][]", field, tracker.core_fields.include?(field),
                             :class => "tracker-#{tracker.id} core-field-#{field}", :id => nil %>
         </td>
@@ -51,7 +51,7 @@
             <%= field.name %>
           </td>
           <% @trackers.each do |tracker| %>
-          <td title="<%= "#{tracker.name}: #{field.name}" %>">
+          <td <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{tracker.name}: #{field.name}")) %>>
             <%= check_box_tag "trackers[#{tracker.id}][custom_field_ids][]", field.id, tracker.custom_fields.include?(field),
                               :class => "tracker-#{tracker.id} custom-field-#{field.id}", :id => nil %>
           </td>

--- a/app/views/trackers/fields.html.erb
+++ b/app/views/trackers/fields.html.erb
@@ -30,7 +30,7 @@
           <%= field_name %>
         </td>
         <% @trackers.each do |tracker| %>
-        <td <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{tracker.name}: #{field_name}")) %>>
+        <td <%= tag.attributes(**tooltip_options("#{tracker.name}: #{field_name}")) %>>
           <%= check_box_tag "trackers[#{tracker.id}][core_fields][]", field, tracker.core_fields.include?(field),
                             :class => "tracker-#{tracker.id} core-field-#{field}", :id => nil %>
         </td>
@@ -51,7 +51,7 @@
             <%= field.name %>
           </td>
           <% @trackers.each do |tracker| %>
-          <td <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{tracker.name}: #{field.name}")) %>>
+          <td <%= tag.attributes(**tooltip_options("#{tracker.name}: #{field.name}")) %>>
             <%= check_box_tag "trackers[#{tracker.id}][custom_field_ids][]", field.id, tracker.custom_fields.include?(field),
                               :class => "tracker-#{tracker.id} custom-field-#{field.id}", :id => nil %>
           </td>

--- a/app/views/users/_list.html.erb
+++ b/app/views/users/_list.html.erb
@@ -6,7 +6,7 @@
   <tr>
     <th class="checkbox hide-when-print">
       <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-        :title => "#{l(:button_check_all)} / #{l(:button_uncheck_all)}" %>
+        :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
     </th>
     <% @query.inline_columns.each do |column| %>
       <%= column_header(@query, column) %>

--- a/app/views/users/_list.html.erb
+++ b/app/views/users/_list.html.erb
@@ -6,7 +6,7 @@
   <tr>
     <th class="checkbox hide-when-print">
       <%= check_box_tag 'check_all', '', false, :class => 'toggle-selection',
-        :data => tooltip_stimulus_attributes(text: "#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
+        **tooltip_options("#{l(:button_check_all)} / #{l(:button_uncheck_all)}") %>
     </th>
     <% @query.inline_columns.each do |column| %>
       <%= column_header(@query, column) %>

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -19,7 +19,7 @@
     <header id="version-<%= version.id %>">
       <% if User.current.allowed_to?(:manage_versions, version.project) %>
         <div class="contextual">
-          <%= link_to sprite_icon('edit', l(:button_edit)), edit_version_path(version), :title => l(:button_edit), :class => 'icon-only icon-edit' %>
+          <%= link_to sprite_icon('edit', l(:button_edit)), edit_version_path(version), :data => tooltip_stimulus_attributes(text: l(:button_edit)), :class => 'icon-only icon-edit' %>
         </div>
       <% end %>
       <h3 class="icon icon-package version inline-flex">

--- a/app/views/versions/index.html.erb
+++ b/app/views/versions/index.html.erb
@@ -19,7 +19,7 @@
     <header id="version-<%= version.id %>">
       <% if User.current.allowed_to?(:manage_versions, version.project) %>
         <div class="contextual">
-          <%= link_to sprite_icon('edit', l(:button_edit)), edit_version_path(version), :data => tooltip_stimulus_attributes(text: l(:button_edit)), :class => 'icon-only icon-edit' %>
+          <%= link_to sprite_icon('edit', l(:button_edit)), edit_version_path(version), **tooltip_options(l(:button_edit)), :class => 'icon-only icon-edit' %>
         </div>
       <% end %>
       <h3 class="icon icon-package version inline-flex">

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -34,7 +34,7 @@
     </td>
     <% for new_status in @statuses -%>
     <% checked = (old_status == new_status) || (transition_counts[[old_status, new_status]] > 0) %>
-    <td class="no-tooltip <%= checked ? 'enabled' : '' %>" title="<%= old_status_name %> &#187; <%= new_status.name %>">
+    <td class="no-tooltip <%= checked ? 'enabled' : '' %>" <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{old_status_name} » #{new_status.name}")) %>>
       <%= transition_tag transition_counts[[old_status, new_status]], old_status, new_status, name %>
     </td>
     <% end -%>

--- a/app/views/workflows/_form.html.erb
+++ b/app/views/workflows/_form.html.erb
@@ -34,7 +34,7 @@
     </td>
     <% for new_status in @statuses -%>
     <% checked = (old_status == new_status) || (transition_counts[[old_status, new_status]] > 0) %>
-    <td class="no-tooltip <%= checked ? 'enabled' : '' %>" <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{old_status_name} » #{new_status.name}")) %>>
+    <td class="no-tooltip <%= checked ? 'enabled' : '' %>" <%= tag.attributes(**tooltip_options("#{old_status_name} » #{new_status.name}")) %>>
       <%= transition_tag transition_counts[[old_status, new_status]], old_status, new_status, name %>
     </td>
     <% end -%>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -24,7 +24,8 @@
     <td>
       <%= link_to(count,
                   {:action => 'edit', :role_id => role, :tracker_id => tracker},
-                  :title => l(:button_edit), :class => ('decoration-red' if count == 0)) %>
+                  :data => tooltip_stimulus_attributes(text: l(:button_edit)),
+                  :class => ('decoration-red' if count == 0)) %>
     </td>
   <% end -%>
 </tr>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -24,7 +24,7 @@
     <td>
       <%= link_to(count,
                   {:action => 'edit', :role_id => role, :tracker_id => tracker},
-                  :data => tooltip_stimulus_attributes(text: l(:button_edit)),
+                  **tooltip_options(l(:button_edit)),
                   :class => ('decoration-red' if count == 0)) %>
     </td>
   <% end -%>

--- a/app/views/workflows/permissions.html.erb
+++ b/app/views/workflows/permissions.html.erb
@@ -64,9 +64,9 @@
           <%= name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
         </td>
         <% for status in @statuses -%>
-        <td class="<%= @permissions[status.id][field].try(:join, ' ') %>" title="<%= name %> (<%= status.name %>)">
+        <td class="<%= @permissions[status.id][field].try(:join, ' ') %>" <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{name} (#{status.name})")) %>>
           <%= field_permission_tag(@permissions, status, field, @roles) %>
-          <% unless status == @statuses.last %><a href="#" class="repeat-value" title="<%= l(:button_copy) %>">&#187;</a><% end %>
+          <% unless status == @statuses.last %><a href="#" class="repeat-value" <%= tag.attributes(data: tooltip_stimulus_attributes(text: l(:button_copy))) %>>&#187;</a><% end %>
         </td>
         <% end -%>
       </tr>
@@ -84,7 +84,7 @@
             <%= field.name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
           </td>
           <% for status in @statuses -%>
-          <td class="<%= @permissions[status.id][field.id.to_s].try(:join, ' ') %>" title="<%= field.name %> (<%= status.name %>)">
+          <td class="<%= @permissions[status.id][field.id.to_s].try(:join, ' ') %>" <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{field.name} (#{status.name})")) %>>
             <%= field_permission_tag(@permissions, status, field, @roles) %>
             <% unless status == @statuses.last %><a href="#" class="repeat-value">&#187;</a><% end %>
           </td>

--- a/app/views/workflows/permissions.html.erb
+++ b/app/views/workflows/permissions.html.erb
@@ -64,9 +64,9 @@
           <%= name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
         </td>
         <% for status in @statuses -%>
-        <td class="<%= @permissions[status.id][field].try(:join, ' ') %>" <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{name} (#{status.name})")) %>>
+        <td class="<%= @permissions[status.id][field].try(:join, ' ') %>" <%= tag.attributes(**tooltip_options("#{name} (#{status.name})")) %>>
           <%= field_permission_tag(@permissions, status, field, @roles) %>
-          <% unless status == @statuses.last %><a href="#" class="repeat-value" <%= tag.attributes(data: tooltip_stimulus_attributes(text: l(:button_copy))) %>>&#187;</a><% end %>
+          <% unless status == @statuses.last %><a href="#" class="repeat-value" <%= tag.attributes(**tooltip_options(l(:button_copy))) %>>&#187;</a><% end %>
         </td>
         <% end -%>
       </tr>
@@ -84,7 +84,7 @@
             <%= field.name %> <%= content_tag('span', '*', :class => 'required') if field_required?(field) %>
           </td>
           <% for status in @statuses -%>
-          <td class="<%= @permissions[status.id][field.id.to_s].try(:join, ' ') %>" <%= tag.attributes(data: tooltip_stimulus_attributes(text: "#{field.name} (#{status.name})")) %>>
+          <td class="<%= @permissions[status.id][field.id.to_s].try(:join, ' ') %>" <%= tag.attributes(**tooltip_options("#{field.name} (#{status.name})")) %>>
             <%= field_permission_tag(@permissions, status, field, @roles) %>
             <% unless status == @statuses.last %><a href="#" class="repeat-value">&#187;</a><% end %>
           </td>

--- a/lib/redmine/quote_reply.rb
+++ b/lib/redmine/quote_reply.rb
@@ -29,7 +29,11 @@ module Redmine
           },
           class: "#{icon_only ? "icon-only" : "icon"} icon-quote"
         }
-        button_params[:title] = l(:button_quote) if icon_only
+        if icon_only
+          tooltip_data = tooltip_stimulus_attributes(text: l(:button_quote))
+          button_params[:data].merge!(tooltip_data.except(:action))
+          button_params[:data][:action] = "#{button_params[:data][:action]} #{tooltip_data[:action]}"
+        end
 
         link_to sprite_icon('quote-filled', l(:button_quote), icon_only: icon_only, style: :filled), '#', button_params
       end

--- a/lib/redmine/quote_reply.rb
+++ b/lib/redmine/quote_reply.rb
@@ -30,9 +30,7 @@ module Redmine
           class: "#{icon_only ? "icon-only" : "icon"} icon-quote"
         }
         if icon_only
-          tooltip_data = tooltip_stimulus_attributes(text: l(:button_quote))
-          button_params[:data].merge!(tooltip_data.except(:action))
-          button_params[:data][:action] = "#{button_params[:data][:action]} #{tooltip_data[:action]}"
+          button_params = tooltip_options(l(:button_quote), button_params)
         end
 
         link_to sprite_icon('quote-filled', l(:button_quote), icon_only: icon_only, style: :filled), '#', button_params

--- a/lib/redmine/wiki_formatting/copypre_scrubber.rb
+++ b/lib/redmine/wiki_formatting/copypre_scrubber.rb
@@ -24,8 +24,14 @@ module Redmine
 
       def button
         icon = ApplicationController.helpers.sprite_icon('copy-pre-content', size: 18)
-        button_copy = ApplicationController.helpers.l(:button_copy)
-        html = '<a class="copy-pre-content-link icon-only" title="' + button_copy + '" data-action="clipboard#copyPre">' + icon + '</a>'
+        button_copy = ERB::Util.html_escape(ApplicationController.helpers.l(:button_copy))
+        html =
+          '<a class="copy-pre-content-link icon-only" ' \
+          'data-controller="tooltip" ' \
+          'data-action="clipboard#copyPre mouseenter->tooltip#show mouseleave->tooltip#hide" ' \
+          "data-tooltip-text-value=\"#{button_copy}\">" +
+          icon +
+          '</a>'
         Nokogiri::HTML5.fragment(html).children.first
       end
     end

--- a/lib/redmine/wiki_formatting/copypre_scrubber.rb
+++ b/lib/redmine/wiki_formatting/copypre_scrubber.rb
@@ -27,9 +27,9 @@ module Redmine
         button_copy = ERB::Util.html_escape(ApplicationController.helpers.l(:button_copy))
         html =
           '<a class="copy-pre-content-link icon-only" ' \
-          'data-controller="tooltip" ' \
-          'data-action="clipboard#copyPre mouseenter->tooltip#show mouseleave->tooltip#hide" ' \
-          "data-tooltip-text-value=\"#{button_copy}\">" +
+          'data-action="clipboard#copyPre" ' \
+          'data-tooltip-target="trigger" ' \
+          "title=\"#{button_copy}\">" +
           icon +
           '</a>'
         Nokogiri::HTML5.fragment(html).children.first

--- a/test/functional/calendars_controller_test.rb
+++ b/test/functional/calendars_controller_test.rb
@@ -148,7 +148,7 @@ class CalendarsControllerTest < Redmine::ControllerTest
     )
     assert_response :success
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[title=?]', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
   end
 
   def test_cross_project_calendar

--- a/test/functional/calendars_controller_test.rb
+++ b/test/functional/calendars_controller_test.rb
@@ -148,7 +148,7 @@ class CalendarsControllerTest < Redmine::ControllerTest
     )
     assert_response :success
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-tooltip-target=?][title=?]', 'trigger', query.description, :text => query.name
   end
 
   def test_cross_project_calendar

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -331,7 +331,8 @@ class IssuesControllerTest < Redmine::ControllerTest
       assert_select 'a.query.selected', 1
       # assert link properties
       assert_select(
-        'a.query.selected[title=?][href=?]',
+        'a.query.selected[data-controller=?][data-tooltip-text-value=?][href=?]',
+        'tooltip',
         'Description for Open issues by priority and tracker',
         '/projects/ecookbook/issues?query_id=5',
         :text => "Open issues by priority and tracker"
@@ -340,7 +341,8 @@ class IssuesControllerTest < Redmine::ControllerTest
       assert_select 'a.icon-clear-query', 1
       # assert clear link properties
       assert_select(
-        'a.icon-clear-query[title=?][href=?]',
+        'a.icon-clear-query[data-controller=?][data-tooltip-text-value=?][href=?]',
+        'tooltip',
         'Clear',
         '/projects/ecookbook/issues?set_filter=1&sort=',
         1
@@ -1834,7 +1836,7 @@ class IssuesControllerTest < Redmine::ControllerTest
     child = Issue.generate!(:parent_issue_id => parent.id)
     get(:index, :params => {:c => %w(parent)})
     assert_select 'td.parent', :text => "#{parent.tracker} ##{parent.id}"
-    assert_select 'td.parent a[title=?]', parent.subject
+    assert_select 'td.parent a[data-controller=?][data-tooltip-text-value=?]', 'tooltip', parent.subject
   end
 
   def test_index_with_parent_subject_column
@@ -2881,7 +2883,7 @@ class IssuesControllerTest < Redmine::ControllerTest
 
     assert_select 'div#watchers ul' do
       assert_select 'li.user-2' do
-        assert_select '.avatar[title=?]', 'John Smith'
+        assert_select '.avatar[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
         assert_select 'a[href="/users/2"]'
         assert_select 'a[class*=delete]'
       end
@@ -2904,7 +2906,7 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
     assert_select 'div#watchers ul' do
       assert_select 'li.user-4' do
-        assert_select 'span.icon-warning[title=?]', l(:notice_invalid_watcher), text: l(:notice_invalid_watcher)
+        assert_select 'span.icon-warning[data-controller=?][data-tooltip-text-value=?]', 'tooltip', l(:notice_invalid_watcher), text: l(:notice_invalid_watcher)
       end
     end
   end
@@ -3084,7 +3086,7 @@ class IssuesControllerTest < Redmine::ControllerTest
 
     journal = Journal.find(1)
     journal_title = l(:label_time_by_author, :time => format_time(journal.updated_on), :author => journal.updated_by)
-    assert_select "#change-1 h4 span.update-info[title=?]", journal_title, :text => '· Edited'
+    assert_select "#change-1 h4 span.update-info[data-controller=?][data-tooltip-text-value=?]", 'tooltip', journal_title, :text => '· Edited'
     assert_select "#change-2 h4 span.update-info", 0
   end
 
@@ -3357,8 +3359,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'div[id=?]', 'time-entry-3' do
-      assert_select 'a[title=?][href=?]', 'Edit', '/time_entries/3/edit'
-      assert_select 'a[title=?][href=?]', 'Delete', '/time_entries/3'
+      assert_select 'a[data-controller=?][data-tooltip-text-value=?][href=?]', 'tooltip', 'Edit', '/time_entries/3/edit'
+      assert_select 'a[data-controller=?][data-tooltip-text-value=?][href=?]', 'tooltip', 'Delete', '/time_entries/3'
 
       assert_select 'ul[class=?]', 'journal-details', :text => /1.00 h/
     end
@@ -3402,13 +3404,13 @@ class IssuesControllerTest < Redmine::ControllerTest
       # The current_user can only see members who belong to projects that the current_user has access to.
       # Since the Redmine Admin user does not belong to any projects visible to the current_user,
       # the Redmine Admin user's name is not displayed in the reaction user list. Instead, "1 other" is shown.
-      assert_select 'a.reaction-button[title=?]', 'Dave Lopper and John Smith' do
+      assert_select 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Dave Lopper and John Smith' do
         assert_select 'span.icon-label', '2'
       end
     end
 
     assert_select 'span[data-reaction-button-id=reaction_journal_1]' do
-      assert_select 'a.reaction-button[title=?]', 'John Smith'
+      assert_select 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
     end
     assert_select 'span[data-reaction-button-id=reaction_journal_2] a.reaction-button'
   end
@@ -4077,8 +4079,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[title=?]', 'View all trackers description', :text => 'View all trackers description'
-      assert_select 'select[name=?][title=?]', 'issue[tracker_id]', 'Description for Bug tracker'
+      assert_select 'a[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'View all trackers description', :text => 'View all trackers description'
+      assert_select 'select[name=?][data-controller=?][data-tooltip-text-value=?]', 'issue[tracker_id]', 'tooltip', 'Description for Bug tracker'
     end
 
     assert_select 'div#trackers_description' do
@@ -4103,8 +4105,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[title=?]', 'View all trackers description', 0
-      assert_select 'select[name=?][title=?]', 'issue[tracker_id]', ''
+      assert_select 'a[data-tooltip-text-value=?]', 'View all trackers description', 0
+      assert_select 'select[name=?][data-tooltip-text-value]', 'issue[tracker_id]', 0
     end
 
     assert_select 'div#trackers_description', 0
@@ -4121,8 +4123,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[title=?]', 'View all issue statuses description', :text => 'View all issue statuses description'
-      assert_select 'select[name=?][title=?]', 'issue[status_id]', 'Description for Assigned issue status'
+      assert_select 'a[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'View all issue statuses description', :text => 'View all issue statuses description'
+      assert_select 'select[name=?][data-controller=?][data-tooltip-text-value=?]', 'issue[status_id]', 'tooltip', 'Description for Assigned issue status'
     end
 
     assert_select 'div#issue_statuses_description' do
@@ -4146,8 +4148,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[title=?]', 'View all issue statuses description', 0
-      assert_select 'select[name=?][title=?]', 'issue[status_id]', ''
+      assert_select 'a[data-tooltip-text-value=?]', 'View all issue statuses description', 0
+      assert_select 'select[name=?][data-tooltip-text-value]', 'issue[status_id]', 0
     end
 
     assert_select 'div#issue_statuses_description', 0
@@ -4451,8 +4453,8 @@ class IssuesControllerTest < Redmine::ControllerTest
                          :issue => {:tracker_id => 3}
     assert_not_nil flash[:notice], "flash was not set"
     assert_select_in flash[:notice],
-                     'a[href=?][title=?]', "/issues/#{issue.id}",
-                     "This is first issue", :text => "##{issue.id}"
+                     'a[href=?][data-controller=?][data-tooltip-text-value=?]', "/issues/#{issue.id}",
+                     'tooltip', "This is first issue", :text => "##{issue.id}"
   end
 
   def test_post_create_without_custom_fields_param
@@ -6177,7 +6179,7 @@ class IssuesControllerTest < Redmine::ControllerTest
 
     assert_response :success
     reason = l(:notice_issue_not_closable_by_blocking_issue)
-    assert_select 'span.icon-warning[title=?]', reason do
+    assert_select 'span.icon-warning[data-controller=?][data-tooltip-text-value=?]', 'tooltip', reason do
       assert_select "svg.icon-svg use:match('href', ?)", /assets\/icons-\w+.svg#icon--warning/
       assert_select 'span.icon-label', test: reason
     end

--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -331,8 +331,8 @@ class IssuesControllerTest < Redmine::ControllerTest
       assert_select 'a.query.selected', 1
       # assert link properties
       assert_select(
-        'a.query.selected[data-controller=?][data-tooltip-text-value=?][href=?]',
-        'tooltip',
+        'a.query.selected[data-tooltip-target=?][title=?][href=?]',
+        'trigger',
         'Description for Open issues by priority and tracker',
         '/projects/ecookbook/issues?query_id=5',
         :text => "Open issues by priority and tracker"
@@ -341,8 +341,8 @@ class IssuesControllerTest < Redmine::ControllerTest
       assert_select 'a.icon-clear-query', 1
       # assert clear link properties
       assert_select(
-        'a.icon-clear-query[data-controller=?][data-tooltip-text-value=?][href=?]',
-        'tooltip',
+        'a.icon-clear-query[data-tooltip-target=?][title=?][href=?]',
+        'trigger',
         'Clear',
         '/projects/ecookbook/issues?set_filter=1&sort=',
         1
@@ -1836,7 +1836,7 @@ class IssuesControllerTest < Redmine::ControllerTest
     child = Issue.generate!(:parent_issue_id => parent.id)
     get(:index, :params => {:c => %w(parent)})
     assert_select 'td.parent', :text => "#{parent.tracker} ##{parent.id}"
-    assert_select 'td.parent a[data-controller=?][data-tooltip-text-value=?]', 'tooltip', parent.subject
+    assert_select 'td.parent a[data-tooltip-target=?][title=?]', 'trigger', parent.subject
   end
 
   def test_index_with_parent_subject_column
@@ -2883,7 +2883,7 @@ class IssuesControllerTest < Redmine::ControllerTest
 
     assert_select 'div#watchers ul' do
       assert_select 'li.user-2' do
-        assert_select '.avatar[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
+        assert_select '.avatar[data-tooltip-target=?][title=?]', 'trigger', 'John Smith'
         assert_select 'a[href="/users/2"]'
         assert_select 'a[class*=delete]'
       end
@@ -2906,7 +2906,7 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
     assert_select 'div#watchers ul' do
       assert_select 'li.user-4' do
-        assert_select 'span.icon-warning[data-controller=?][data-tooltip-text-value=?]', 'tooltip', l(:notice_invalid_watcher), text: l(:notice_invalid_watcher)
+        assert_select 'span.icon-warning[data-tooltip-target=?][title=?]', 'trigger', l(:notice_invalid_watcher), text: l(:notice_invalid_watcher)
       end
     end
   end
@@ -3086,7 +3086,7 @@ class IssuesControllerTest < Redmine::ControllerTest
 
     journal = Journal.find(1)
     journal_title = l(:label_time_by_author, :time => format_time(journal.updated_on), :author => journal.updated_by)
-    assert_select "#change-1 h4 span.update-info[data-controller=?][data-tooltip-text-value=?]", 'tooltip', journal_title, :text => '· Edited'
+    assert_select "#change-1 h4 span.update-info[data-tooltip-target=?][title=?]", 'trigger', journal_title, :text => '· Edited'
     assert_select "#change-2 h4 span.update-info", 0
   end
 
@@ -3359,8 +3359,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'div[id=?]', 'time-entry-3' do
-      assert_select 'a[data-controller=?][data-tooltip-text-value=?][href=?]', 'tooltip', 'Edit', '/time_entries/3/edit'
-      assert_select 'a[data-controller=?][data-tooltip-text-value=?][href=?]', 'tooltip', 'Delete', '/time_entries/3'
+      assert_select 'a[data-tooltip-target=?][title=?][href=?]', 'trigger', 'Edit', '/time_entries/3/edit'
+      assert_select 'a[data-tooltip-target=?][title=?][href=?]', 'trigger', 'Delete', '/time_entries/3'
 
       assert_select 'ul[class=?]', 'journal-details', :text => /1.00 h/
     end
@@ -3404,13 +3404,13 @@ class IssuesControllerTest < Redmine::ControllerTest
       # The current_user can only see members who belong to projects that the current_user has access to.
       # Since the Redmine Admin user does not belong to any projects visible to the current_user,
       # the Redmine Admin user's name is not displayed in the reaction user list. Instead, "1 other" is shown.
-      assert_select 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Dave Lopper and John Smith' do
+      assert_select 'a.reaction-button[data-tooltip-target=?][title=?]', 'trigger', 'Dave Lopper and John Smith' do
         assert_select 'span.icon-label', '2'
       end
     end
 
     assert_select 'span[data-reaction-button-id=reaction_journal_1]' do
-      assert_select 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
+      assert_select 'a.reaction-button[data-tooltip-target=?][title=?]', 'trigger', 'John Smith'
     end
     assert_select 'span[data-reaction-button-id=reaction_journal_2] a.reaction-button'
   end
@@ -4079,8 +4079,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'View all trackers description', :text => 'View all trackers description'
-      assert_select 'select[name=?][data-controller=?][data-tooltip-text-value=?]', 'issue[tracker_id]', 'tooltip', 'Description for Bug tracker'
+      assert_select 'a[data-tooltip-target=?][title=?]', 'trigger', 'View all trackers description', :text => 'View all trackers description'
+      assert_select 'select[name=?][data-tooltip-target=?][title=?]', 'issue[tracker_id]', 'trigger', 'Description for Bug tracker'
     end
 
     assert_select 'div#trackers_description' do
@@ -4105,8 +4105,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[data-tooltip-text-value=?]', 'View all trackers description', 0
-      assert_select 'select[name=?][data-tooltip-text-value]', 'issue[tracker_id]', 0
+      assert_select 'a[title=?]', 'View all trackers description', 0
+      assert_select 'select[name=?][data-tooltip-target]', 'issue[tracker_id]', 0
     end
 
     assert_select 'div#trackers_description', 0
@@ -4123,8 +4123,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'View all issue statuses description', :text => 'View all issue statuses description'
-      assert_select 'select[name=?][data-controller=?][data-tooltip-text-value=?]', 'issue[status_id]', 'tooltip', 'Description for Assigned issue status'
+      assert_select 'a[data-tooltip-target=?][title=?]', 'trigger', 'View all issue statuses description', :text => 'View all issue statuses description'
+      assert_select 'select[name=?][data-tooltip-target=?][title=?]', 'issue[status_id]', 'trigger', 'Description for Assigned issue status'
     end
 
     assert_select 'div#issue_statuses_description' do
@@ -4148,8 +4148,8 @@ class IssuesControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'form#issue-form' do
-      assert_select 'a[data-tooltip-text-value=?]', 'View all issue statuses description', 0
-      assert_select 'select[name=?][data-tooltip-text-value]', 'issue[status_id]', 0
+      assert_select 'a[title=?]', 'View all issue statuses description', 0
+      assert_select 'select[name=?][data-tooltip-target]', 'issue[status_id]', 0
     end
 
     assert_select 'div#issue_statuses_description', 0
@@ -4453,8 +4453,8 @@ class IssuesControllerTest < Redmine::ControllerTest
                          :issue => {:tracker_id => 3}
     assert_not_nil flash[:notice], "flash was not set"
     assert_select_in flash[:notice],
-                     'a[href=?][data-controller=?][data-tooltip-text-value=?]', "/issues/#{issue.id}",
-                     'tooltip', "This is first issue", :text => "##{issue.id}"
+                     'a[href=?][data-tooltip-target=?][title=?]', "/issues/#{issue.id}",
+                     'trigger', "This is first issue", :text => "##{issue.id}"
   end
 
   def test_post_create_without_custom_fields_param
@@ -6179,7 +6179,7 @@ class IssuesControllerTest < Redmine::ControllerTest
 
     assert_response :success
     reason = l(:notice_issue_not_closable_by_blocking_issue)
-    assert_select 'span.icon-warning[data-controller=?][data-tooltip-text-value=?]', 'tooltip', reason do
+    assert_select 'span.icon-warning[data-tooltip-target=?][title=?]', 'trigger', reason do
       assert_select "svg.icon-svg use:match('href', ?)", /assets\/icons-\w+.svg#icon--warning/
       assert_select 'span.icon-label', test: reason
     end

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -264,7 +264,7 @@ class ProjectsControllerTest < Redmine::ControllerTest
     get :index, :params => { :query_id => query.id }
     assert_response :success
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[title=?]', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
   end
 
   def test_index_should_retrieve_default_query
@@ -275,7 +275,7 @@ class ProjectsControllerTest < Redmine::ControllerTest
       @request.session[:user_id] = user_id
       get :index
       assert_select 'h2', text: query.name
-      assert_select '#sidebar a.query.selected[title=?]', query.description, :text => query.name
+      assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
     end
   end
 

--- a/test/functional/projects_controller_test.rb
+++ b/test/functional/projects_controller_test.rb
@@ -264,7 +264,7 @@ class ProjectsControllerTest < Redmine::ControllerTest
     get :index, :params => { :query_id => query.id }
     assert_response :success
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-tooltip-target=?][title=?]', 'trigger', query.description, :text => query.name
   end
 
   def test_index_should_retrieve_default_query
@@ -275,7 +275,7 @@ class ProjectsControllerTest < Redmine::ControllerTest
       @request.session[:user_id] = user_id
       get :index
       assert_select 'h2', text: query.name
-      assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
+      assert_select '#sidebar a.query.selected[data-tooltip-target=?][title=?]', 'trigger', query.description, :text => query.name
     end
   end
 

--- a/test/functional/timelog_controller_test.rb
+++ b/test/functional/timelog_controller_test.rb
@@ -1684,7 +1684,7 @@ class TimelogControllerTest < Redmine::ControllerTest
     get :index, :params => {:project_id => 'ecookbook', :query_id => query.id}
     assert_response :success
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[title=?]', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
   end
 
   def test_index_atom_feed

--- a/test/functional/timelog_controller_test.rb
+++ b/test/functional/timelog_controller_test.rb
@@ -1684,7 +1684,7 @@ class TimelogControllerTest < Redmine::ControllerTest
     get :index, :params => {:project_id => 'ecookbook', :query_id => query.id}
     assert_response :success
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-tooltip-target=?][title=?]', 'trigger', query.description, :text => query.name
   end
 
   def test_index_atom_feed

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -202,7 +202,7 @@ class UsersControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[title=?]', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
   end
 
   def test_index_csv

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -202,7 +202,7 @@ class UsersControllerTest < Redmine::ControllerTest
     assert_response :success
 
     assert_select 'h2', :text => query.name
-    assert_select '#sidebar a.query.selected[data-controller=?][data-tooltip-text-value=?]', 'tooltip', query.description, :text => query.name
+    assert_select '#sidebar a.query.selected[data-tooltip-target=?][title=?]', 'trigger', query.description, :text => query.name
   end
 
   def test_index_csv

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -139,7 +139,7 @@ class WorkflowsControllerTest < Redmine::ControllerTest
     assert_select 'table.workflows.transitions-always tbody tr:nth-child(2)' do
       assert_select 'td.name', :text => 'New'
       # assert that the td is enabled
-      assert_select "td.enabled[title='New » New']"
+      assert_select "td.enabled[data-controller='tooltip'][data-tooltip-text-value='New » New']"
       # assert that the checkbox is disabled and checked
       assert_select "input[name='transitions[1][1][always]'][checked=?][disabled=?]", 'checked', 'disabled', 1
     end

--- a/test/functional/workflows_controller_test.rb
+++ b/test/functional/workflows_controller_test.rb
@@ -139,7 +139,7 @@ class WorkflowsControllerTest < Redmine::ControllerTest
     assert_select 'table.workflows.transitions-always tbody tr:nth-child(2)' do
       assert_select 'td.name', :text => 'New'
       # assert that the td is enabled
-      assert_select "td.enabled[data-controller='tooltip'][data-tooltip-text-value='New » New']"
+      assert_select "td.enabled[data-tooltip-target='trigger'][title='New » New']"
       # assert that the checkbox is disabled and checked
       assert_select "input[name='transitions[1][1][always]'][checked=?][disabled=?]", 'checked', 'disabled', 1
     end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -250,13 +250,13 @@ class ApplicationHelperTest < Redmine::HelperTest
     issue_link = link_to('#3',
                          {:controller => 'issues', :action => 'show', :id => 3},
                          :class => Issue.find(3).css_classes,
-                         :title => 'Bug: Error 281 when updating a recipe (New)')
+                         :data => tooltip_stimulus_attributes(text: 'Bug: Error 281 when updating a recipe (New)'))
     ext_issue_link =
       link_to(
         'Bug #3: Error 281 when updating a recipe',
         {:controller => 'issues', :action => 'show', :id => 3},
         :class => Issue.find(3).css_classes,
-        :title => 'Status: New'
+        :data => tooltip_stimulus_attributes(text: 'Status: New')
       )
     note_link =
       link_to(
@@ -264,7 +264,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :title => 'Bug: Error 281 when updating a recipe (New)'
+        :data => tooltip_stimulus_attributes(text: 'Bug: Error 281 when updating a recipe (New)')
       )
     ext_note_link =
       link_to(
@@ -272,7 +272,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :title => 'Status: New'
+        :data => tooltip_stimulus_attributes(text: 'Status: New')
       )
     note_link2 =
       link_to(
@@ -280,7 +280,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :title => 'Bug: Error 281 when updating a recipe (New)'
+        :data => tooltip_stimulus_attributes(text: 'Bug: Error 281 when updating a recipe (New)')
       )
     ext_note_link2 =
       link_to(
@@ -288,7 +288,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :title => 'Status: New'
+        :data => tooltip_stimulus_attributes(text: 'Status: New')
       )
     revision_link =
       link_to(
@@ -296,7 +296,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 1},
         :class => 'changeset',
-        :title => 'My very first commit do not escaping #<>&'
+        :data => tooltip_stimulus_attributes(text: 'My very first commit do not escaping #<>&')
       )
     revision_link2 =
       link_to(
@@ -304,14 +304,15 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 2},
         :class => 'changeset',
-        :title => 'This commit fixes #1, #2 and references #1 & #3'
+        :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3')
       )
     changeset_link2 =
       link_to(
         '691322a8eb01e11fd7',
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 1},
-        :class => 'changeset', :title => 'My very first commit do not escaping #<>&'
+        :class => 'changeset',
+        :data => tooltip_stimulus_attributes(text: 'My very first commit do not escaping #<>&')
       )
     document_link =
       link_to(
@@ -534,7 +535,7 @@ class ApplicationHelperTest < Redmine::HelperTest
                              {:controller => 'repositories', :action => 'revision',
                               :id => 'ecookbook', :repository_id => 10, :rev => 2},
                              :class => 'changeset',
-                             :title => 'This commit fixes #1, #2 and references #1 & #3')
+                             :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3'))
     to_test = {
       # documents
       'document:"Test document"'              => 'document:"Test document"',
@@ -597,14 +598,14 @@ class ApplicationHelperTest < Redmine::HelperTest
     str = link_to_issue(issue, :subject => false)
     result = link_to("Bug ##{issue.id}", "/issues/#{issue.id}",
                      :class => issue.css_classes,
-                     :title => "#{long_str}0123456...")
+                     :data => tooltip_stimulus_attributes(text: "#{long_str}0123456..."))
     assert_equal result, str
 
     issue = Issue.generate!(:subject => "<&>#{long_str}01234567890123456789")
     str = link_to_issue(issue, :subject => false)
     result = link_to("Bug ##{issue.id}", "/issues/#{issue.id}",
                      :class => issue.css_classes,
-                     :title => "<&>#{long_str}0123...")
+                     :data => tooltip_stimulus_attributes(text: "<&>#{long_str}0123..."))
     assert_equal result, str
   end
 
@@ -620,21 +621,21 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 2},
         :class => 'changeset',
-        :title => 'This commit fixes #1, #2 and references #1 & #3'
+        :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3')
       )
     svn_changeset_link =
       link_to(
         'svn_repo-1|r123',
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 'svn_repo-1', :rev => 123},
-        :class => 'changeset', :title => ''
+        :class => 'changeset'
       )
     hg_changeset_link =
       link_to(
         'hg1|abcd',
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 'hg1', :rev => 'abcd'},
-        :class => 'changeset', :title => ''
+        :class => 'changeset'
       )
     source_link = link_to('source:some/file',
                           {:controller => 'repositories', :action => 'entry',
@@ -677,21 +678,21 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 2},
         :class => 'changeset',
-        :title => 'This commit fixes #1, #2 and references #1 & #3'
+        :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3')
       )
     svn_changeset_link =
       link_to(
         'ecookbook:svn1|r123',
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 'svn1', :rev => 123},
-        :class => 'changeset', :title => ''
+        :class => 'changeset'
       )
     hg_changeset_link =
       link_to(
         'ecookbook:hg1|abcd',
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 'hg1', :rev => 'abcd'},
-        :class => 'changeset', :title => ''
+        :class => 'changeset'
       )
     source_link =
       link_to(
@@ -745,7 +746,8 @@ class ApplicationHelperTest < Redmine::HelperTest
           :repository_id => r.id,
           :rev        => 'abcd',
         },
-        :class => 'changeset', :title => 'test commit'
+        :class => 'changeset',
+        :data => tooltip_stimulus_attributes(text: 'test commit')
       )
     to_test = {
       'commit:abcd' => changeset_link,
@@ -777,7 +779,8 @@ class ApplicationHelperTest < Redmine::HelperTest
           :repository_id => r.id,
           :rev        => '123',
         },
-        :class => 'changeset', :title => 'test commit'
+        :class => 'changeset',
+        :data => tooltip_stimulus_attributes(text: 'test commit')
       )
     changeset_link_commit =
       link_to(
@@ -789,7 +792,8 @@ class ApplicationHelperTest < Redmine::HelperTest
           :repository_id => r.id,
           :rev        => 'abcd',
         },
-        :class => 'changeset', :title => 'test commit'
+        :class => 'changeset',
+        :data => tooltip_stimulus_attributes(text: 'test commit')
       )
     to_test = {
       'r123' => changeset_link_rev,
@@ -1221,7 +1225,7 @@ class ApplicationHelperTest < Redmine::HelperTest
     result2 = link_to('#1',
                       "/issues/1",
                       :class => Issue.find(1).css_classes,
-                      :title => "Bug: Cannot print recipes (New)")
+                      :data => tooltip_stimulus_attributes(text: "Bug: Cannot print recipes (New)"))
     pre = <<~PRE
       <pre data-clipboard-target="pre">
       [[CookBook documentation]]
@@ -1555,7 +1559,7 @@ class ApplicationHelperTest < Redmine::HelperTest
       # heading that contains inline code
       assert_match(
         Regexp.new(
-          '<div class="contextual heading-2" title="Edit this section" id="section-4">' \
+          '<div class="contextual heading-2"[^>]*data-tooltip-text-value="Edit this section"[^>]*id="section-4"[^>]*>' \
           '<a class="icon-only icon-edit" href="/projects/1/wiki/Test/edit\?section=4">' \
           '<svg class="s18 icon-svg" aria-hidden="true"><use href="\/assets\/icons-.*.svg#icon--edit"></use></svg>' \
           '<span class="icon-label">Edit this section</span>' \
@@ -1570,7 +1574,7 @@ class ApplicationHelperTest < Redmine::HelperTest
       # last heading
       assert_match(
         Regexp.new(
-          '<div class="contextual heading-2" title="Edit this section" id="section-5">' \
+          '<div class="contextual heading-2"[^>]*data-tooltip-text-value="Edit this section"[^>]*id="section-5"[^>]*>' \
           '<a class="icon-only icon-edit" href="/projects/1/wiki/Test/edit\?section=5">' \
           '<svg class="s18 icon-svg" aria-hidden="true"><use href="\/assets\/icons-.*.svg#icon--edit"></use></svg>' \
           '<span class="icon-label">Edit this section</span>' \
@@ -1611,7 +1615,7 @@ class ApplicationHelperTest < Redmine::HelperTest
 
       assert_match(
         Regexp.new(
-          '<div class="contextual heading-2" title="Edit this section" id="section-2">' \
+          '<div class="contextual heading-2"[^>]*data-tooltip-text-value="Edit this section"[^>]*id="section-2"[^>]*>' \
           '<a class="icon-only icon-edit" href="/projects/1/wiki/Test/edit\?section=2">' \
           '<svg class="s18 icon-svg" aria-hidden="true"><use href="/assets/icons-.*\.svg#icon--edit"></use></svg>' \
           '<span class="icon-label">Edit this section</span>' \
@@ -1689,11 +1693,13 @@ class ApplicationHelperTest < Redmine::HelperTest
     pages_by_parent_id = {nil => [parent_page], parent_page.id => [child_page]}
     result = render_page_hierarchy(pages_by_parent_id, nil, :timestamp => true)
     assert_select_in(
-      result, 'ul.pages-hierarchy li a[title=?]',
+      result, 'ul.pages-hierarchy li a[data-controller=?][data-tooltip-text-value=?]',
+      'tooltip',
       l(:label_updated_time,
         distance_of_time_in_words(Time.now, parent_page.updated_on)))
     assert_select_in(
-      result, 'ul.pages-hierarchy li ul.pages-hierarchy a[title=?]',
+      result, 'ul.pages-hierarchy li ul.pages-hierarchy a[data-controller=?][data-tooltip-text-value=?]',
+      'tooltip',
       l(:label_updated_time,
         distance_of_time_in_words(Time.now, child_page.updated_on)))
   end
@@ -1811,7 +1817,10 @@ class ApplicationHelperTest < Redmine::HelperTest
 
   def test_thumbnail_tag
     attachment = Attachment.find(3)
-    assert_select_in thumbnail_tag(attachment), 'div.thumbnail[title=?]', 'logo.gif' do
+    assert_select_in thumbnail_tag(attachment),
+                     'div.thumbnail[data-controller=?][data-tooltip-text-value=?]',
+                     'tooltip',
+                     'logo.gif' do
       assert_select 'a[href=?]', '/attachments/3' do
         assert_select 'img[alt=?][src=?][loading="lazy"]', "logo.gif", "/attachments/thumbnail/3/200"
       end
@@ -1854,7 +1863,12 @@ class ApplicationHelperTest < Redmine::HelperTest
       [news(:news_001),                   '<a href="/news/1">eCookbook first release !</a>'],
       [projects(:projects_001),           '<a href="/projects/ecookbook">eCookbook</a>'],
       [users(:users_001),                 '<a class="user active" href="/users/1">Redmine Admin</a>'],
-      [versions(:versions_001),           '<a title="07/01/2006" href="/versions/1">eCookbook - 0.1</a>'],
+      [
+        versions(:versions_001),
+        '<a data-controller="tooltip" ' \
+        'data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide keydown.esc-&gt;tooltip#hide" ' \
+        'data-tooltip-text-value="07/01/2006" href="/versions/1">eCookbook - 0.1</a>'
+      ],
       [wiki_pages(:wiki_pages_001),
        '<a href="/projects/ecookbook/wiki/CookBook_documentation">CookBook documentation</a>']
     ].each do |record, link|
@@ -2187,10 +2201,19 @@ class ApplicationHelperTest < Redmine::HelperTest
     assert_nil time_tag(nil)
     with_locale 'en' do
       travel_to Time.zone.parse('2022-12-30T01:00:00Z') do
-        assert_equal "<abbr title=\"12/28/2022 01:00 AM\">2 days</abbr>", time_tag(2.days.ago)
+        assert_select_in time_tag(2.days.ago),
+                         'abbr[data-controller=?][data-tooltip-text-value=?]',
+                         'tooltip',
+                         '12/28/2022 01:00 AM',
+                         :text => '2 days'
 
         @project = Project.find(1)
-        assert_equal "<a title=\"12/28/2022 01:00 AM\" href=\"/projects/ecookbook/activity?from=2022-12-28\">2 days</a>", time_tag(2.days.ago)
+        assert_select_in time_tag(2.days.ago),
+                         'a[href=?][data-controller=?][data-tooltip-text-value=?]',
+                         '/projects/ecookbook/activity?from=2022-12-28',
+                         'tooltip',
+                         '12/28/2022 01:00 AM',
+                         :text => '2 days'
       end
     end
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -250,13 +250,13 @@ class ApplicationHelperTest < Redmine::HelperTest
     issue_link = link_to('#3',
                          {:controller => 'issues', :action => 'show', :id => 3},
                          :class => Issue.find(3).css_classes,
-                         :data => tooltip_stimulus_attributes(text: 'Bug: Error 281 when updating a recipe (New)'))
+                         **tooltip_options('Bug: Error 281 when updating a recipe (New)'))
     ext_issue_link =
       link_to(
         'Bug #3: Error 281 when updating a recipe',
         {:controller => 'issues', :action => 'show', :id => 3},
         :class => Issue.find(3).css_classes,
-        :data => tooltip_stimulus_attributes(text: 'Status: New')
+        **tooltip_options('Status: New')
       )
     note_link =
       link_to(
@@ -264,7 +264,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :data => tooltip_stimulus_attributes(text: 'Bug: Error 281 when updating a recipe (New)')
+        **tooltip_options('Bug: Error 281 when updating a recipe (New)')
       )
     ext_note_link =
       link_to(
@@ -272,7 +272,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :data => tooltip_stimulus_attributes(text: 'Status: New')
+        **tooltip_options('Status: New')
       )
     note_link2 =
       link_to(
@@ -280,7 +280,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :data => tooltip_stimulus_attributes(text: 'Bug: Error 281 when updating a recipe (New)')
+        **tooltip_options('Bug: Error 281 when updating a recipe (New)')
       )
     ext_note_link2 =
       link_to(
@@ -288,7 +288,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'issues', :action => 'show',
          :id => 3, :anchor => 'note-14'},
         :class => Issue.find(3).css_classes,
-        :data => tooltip_stimulus_attributes(text: 'Status: New')
+        **tooltip_options('Status: New')
       )
     revision_link =
       link_to(
@@ -296,7 +296,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 1},
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'My very first commit do not escaping #<>&')
+        **tooltip_options('My very first commit do not escaping #<>&')
       )
     revision_link2 =
       link_to(
@@ -304,7 +304,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 2},
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3')
+        **tooltip_options('This commit fixes #1, #2 and references #1 & #3')
       )
     changeset_link2 =
       link_to(
@@ -312,7 +312,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 1},
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'My very first commit do not escaping #<>&')
+        **tooltip_options('My very first commit do not escaping #<>&')
       )
     document_link =
       link_to(
@@ -535,7 +535,7 @@ class ApplicationHelperTest < Redmine::HelperTest
                              {:controller => 'repositories', :action => 'revision',
                               :id => 'ecookbook', :repository_id => 10, :rev => 2},
                              :class => 'changeset',
-                             :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3'))
+                             **tooltip_options('This commit fixes #1, #2 and references #1 & #3'))
     to_test = {
       # documents
       'document:"Test document"'              => 'document:"Test document"',
@@ -598,14 +598,14 @@ class ApplicationHelperTest < Redmine::HelperTest
     str = link_to_issue(issue, :subject => false)
     result = link_to("Bug ##{issue.id}", "/issues/#{issue.id}",
                      :class => issue.css_classes,
-                     :data => tooltip_stimulus_attributes(text: "#{long_str}0123456..."))
+                     **tooltip_options("#{long_str}0123456..."))
     assert_equal result, str
 
     issue = Issue.generate!(:subject => "<&>#{long_str}01234567890123456789")
     str = link_to_issue(issue, :subject => false)
     result = link_to("Bug ##{issue.id}", "/issues/#{issue.id}",
                      :class => issue.css_classes,
-                     :data => tooltip_stimulus_attributes(text: "<&>#{long_str}0123..."))
+                     **tooltip_options("<&>#{long_str}0123..."))
     assert_equal result, str
   end
 
@@ -621,7 +621,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 2},
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3')
+        **tooltip_options('This commit fixes #1, #2 and references #1 & #3')
       )
     svn_changeset_link =
       link_to(
@@ -678,7 +678,7 @@ class ApplicationHelperTest < Redmine::HelperTest
         {:controller => 'repositories', :action => 'revision',
          :id => 'ecookbook', :repository_id => 10, :rev => 2},
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'This commit fixes #1, #2 and references #1 & #3')
+        **tooltip_options('This commit fixes #1, #2 and references #1 & #3')
       )
     svn_changeset_link =
       link_to(
@@ -747,7 +747,7 @@ class ApplicationHelperTest < Redmine::HelperTest
           :rev        => 'abcd',
         },
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'test commit')
+        **tooltip_options('test commit')
       )
     to_test = {
       'commit:abcd' => changeset_link,
@@ -780,7 +780,7 @@ class ApplicationHelperTest < Redmine::HelperTest
           :rev        => '123',
         },
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'test commit')
+        **tooltip_options('test commit')
       )
     changeset_link_commit =
       link_to(
@@ -793,7 +793,7 @@ class ApplicationHelperTest < Redmine::HelperTest
           :rev        => 'abcd',
         },
         :class => 'changeset',
-        :data => tooltip_stimulus_attributes(text: 'test commit')
+        **tooltip_options('test commit')
       )
     to_test = {
       'r123' => changeset_link_rev,
@@ -1225,7 +1225,7 @@ class ApplicationHelperTest < Redmine::HelperTest
     result2 = link_to('#1',
                       "/issues/1",
                       :class => Issue.find(1).css_classes,
-                      :data => tooltip_stimulus_attributes(text: "Bug: Cannot print recipes (New)"))
+                      **tooltip_options("Bug: Cannot print recipes (New)"))
     pre = <<~PRE
       <pre data-clipboard-target="pre">
       [[CookBook documentation]]
@@ -1559,7 +1559,7 @@ class ApplicationHelperTest < Redmine::HelperTest
       # heading that contains inline code
       assert_match(
         Regexp.new(
-          '<div class="contextual heading-2"[^>]*data-tooltip-text-value="Edit this section"[^>]*id="section-4"[^>]*>' \
+          '<div class="contextual heading-2"[^>]*title="Edit this section"[^>]*data-tooltip-target="trigger"[^>]*id="section-4"[^>]*>' \
           '<a class="icon-only icon-edit" href="/projects/1/wiki/Test/edit\?section=4">' \
           '<svg class="s18 icon-svg" aria-hidden="true"><use href="\/assets\/icons-.*.svg#icon--edit"></use></svg>' \
           '<span class="icon-label">Edit this section</span>' \
@@ -1574,7 +1574,7 @@ class ApplicationHelperTest < Redmine::HelperTest
       # last heading
       assert_match(
         Regexp.new(
-          '<div class="contextual heading-2"[^>]*data-tooltip-text-value="Edit this section"[^>]*id="section-5"[^>]*>' \
+          '<div class="contextual heading-2"[^>]*title="Edit this section"[^>]*data-tooltip-target="trigger"[^>]*id="section-5"[^>]*>' \
           '<a class="icon-only icon-edit" href="/projects/1/wiki/Test/edit\?section=5">' \
           '<svg class="s18 icon-svg" aria-hidden="true"><use href="\/assets\/icons-.*.svg#icon--edit"></use></svg>' \
           '<span class="icon-label">Edit this section</span>' \
@@ -1615,7 +1615,7 @@ class ApplicationHelperTest < Redmine::HelperTest
 
       assert_match(
         Regexp.new(
-          '<div class="contextual heading-2"[^>]*data-tooltip-text-value="Edit this section"[^>]*id="section-2"[^>]*>' \
+          '<div class="contextual heading-2"[^>]*title="Edit this section"[^>]*data-tooltip-target="trigger"[^>]*id="section-2"[^>]*>' \
           '<a class="icon-only icon-edit" href="/projects/1/wiki/Test/edit\?section=2">' \
           '<svg class="s18 icon-svg" aria-hidden="true"><use href="/assets/icons-.*\.svg#icon--edit"></use></svg>' \
           '<span class="icon-label">Edit this section</span>' \
@@ -1693,13 +1693,13 @@ class ApplicationHelperTest < Redmine::HelperTest
     pages_by_parent_id = {nil => [parent_page], parent_page.id => [child_page]}
     result = render_page_hierarchy(pages_by_parent_id, nil, :timestamp => true)
     assert_select_in(
-      result, 'ul.pages-hierarchy li a[data-controller=?][data-tooltip-text-value=?]',
-      'tooltip',
+      result, 'ul.pages-hierarchy li a[data-tooltip-target=?][title=?]',
+      'trigger',
       l(:label_updated_time,
         distance_of_time_in_words(Time.now, parent_page.updated_on)))
     assert_select_in(
-      result, 'ul.pages-hierarchy li ul.pages-hierarchy a[data-controller=?][data-tooltip-text-value=?]',
-      'tooltip',
+      result, 'ul.pages-hierarchy li ul.pages-hierarchy a[data-tooltip-target=?][title=?]',
+      'trigger',
       l(:label_updated_time,
         distance_of_time_in_words(Time.now, child_page.updated_on)))
   end
@@ -1818,8 +1818,8 @@ class ApplicationHelperTest < Redmine::HelperTest
   def test_thumbnail_tag
     attachment = Attachment.find(3)
     assert_select_in thumbnail_tag(attachment),
-                     'div.thumbnail[data-controller=?][data-tooltip-text-value=?]',
-                     'tooltip',
+                     'div.thumbnail[data-tooltip-target=?][title=?]',
+                     'trigger',
                      'logo.gif' do
       assert_select 'a[href=?]', '/attachments/3' do
         assert_select 'img[alt=?][src=?][loading="lazy"]', "logo.gif", "/attachments/thumbnail/3/200"
@@ -1865,9 +1865,7 @@ class ApplicationHelperTest < Redmine::HelperTest
       [users(:users_001),                 '<a class="user active" href="/users/1">Redmine Admin</a>'],
       [
         versions(:versions_001),
-        '<a data-controller="tooltip" ' \
-        'data-action="mouseenter-&gt;tooltip#show mouseleave-&gt;tooltip#hide focusin-&gt;tooltip#show focusout-&gt;tooltip#hide keydown.esc-&gt;tooltip#hide" ' \
-        'data-tooltip-text-value="07/01/2006" href="/versions/1">eCookbook - 0.1</a>'
+        '<a title="07/01/2006" data-tooltip-target="trigger" href="/versions/1">eCookbook - 0.1</a>'
       ],
       [wiki_pages(:wiki_pages_001),
        '<a href="/projects/ecookbook/wiki/CookBook_documentation">CookBook documentation</a>']
@@ -2202,16 +2200,16 @@ class ApplicationHelperTest < Redmine::HelperTest
     with_locale 'en' do
       travel_to Time.zone.parse('2022-12-30T01:00:00Z') do
         assert_select_in time_tag(2.days.ago),
-                         'abbr[data-controller=?][data-tooltip-text-value=?]',
-                         'tooltip',
+                         'abbr[data-tooltip-target=?][title=?]',
+                         'trigger',
                          '12/28/2022 01:00 AM',
                          :text => '2 days'
 
         @project = Project.find(1)
         assert_select_in time_tag(2.days.ago),
-                         'a[href=?][data-controller=?][data-tooltip-text-value=?]',
+                         'a[href=?][data-tooltip-target=?][title=?]',
                          '/projects/ecookbook/activity?from=2022-12-28',
-                         'tooltip',
+                         'trigger',
                          '12/28/2022 01:00 AM',
                          :text => '2 days'
       end
@@ -2317,5 +2315,31 @@ class ApplicationHelperTest < Redmine::HelperTest
     with_settings :text_formatting => '' do
       assert_equal({}, wiki_textarea_stimulus_attributes)
     end
+  end
+
+  def test_tooltip_options
+    options = {
+      class: 'icon-only',
+      data: {controller: 'clipboard', action: 'clipboard#copy'}
+    }
+
+    assert_equal(
+      {
+        class: 'icon-only',
+        title: 'Copy',
+        data: {
+          controller: 'clipboard',
+          action: 'clipboard#copy',
+          tooltip_target: 'trigger'
+        }
+      },
+      tooltip_options('Copy', options)
+    )
+  end
+
+  def test_tooltip_options_with_blank_text
+    options = {data: {controller: 'clipboard'}}
+
+    assert_same options, tooltip_options('', options)
   end
 end

--- a/test/helpers/avatars_helper_test.rb
+++ b/test/helpers/avatars_helper_test.rb
@@ -64,8 +64,7 @@ class AvatarsHelperTest < Redmine::HelperTest
   end
 
   def test_avatar_with_html_option
-    # Non-avatar options should be considered html options
-    assert_include 'title="John Smith"', avatar('jsmith <jsmith@somenet.foo>', :title => 'John Smith')
+    assert_include 'data-tooltip-text-value="John Smith"', avatar('jsmith <jsmith@somenet.foo>', :title => 'John Smith')
   end
 
   def test_avatar_css_class

--- a/test/helpers/avatars_helper_test.rb
+++ b/test/helpers/avatars_helper_test.rb
@@ -64,7 +64,9 @@ class AvatarsHelperTest < Redmine::HelperTest
   end
 
   def test_avatar_with_html_option
-    assert_include 'data-tooltip-text-value="John Smith"', avatar('jsmith <jsmith@somenet.foo>', :title => 'John Smith')
+    avatar = avatar('jsmith <jsmith@somenet.foo>', :title => 'John Smith')
+    assert_include 'title="John Smith"', avatar
+    assert_include 'data-tooltip-target="trigger"', avatar
   end
 
   def test_avatar_css_class

--- a/test/helpers/custom_fields_helper_test.rb
+++ b/test/helpers/custom_fields_helper_test.rb
@@ -29,16 +29,16 @@ class CustomFieldsHelperTest < Redmine::HelperTest
     assert_equal 'No', format_value('0', CustomField.new(:field_format => 'bool'))
   end
 
-  def test_label_tag_should_include_description_as_span_title_if_present
+  def test_label_tag_should_include_description_as_stimulus_tooltip_if_present
     field = CustomField.new(:field_format => 'string', :description => 'This is the description')
     tag = custom_field_label_tag('foo', CustomValue.new(:custom_field => field))
-    assert_select_in tag, 'label span[title=?]', 'This is the description'
+    assert_select_in tag, 'label span[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'This is the description'
   end
 
-  def test_label_tag_should_not_include_title_if_description_is_blank
+  def test_label_tag_should_not_include_tooltip_if_description_is_blank
     field = CustomField.new(:field_format => 'string')
     tag = custom_field_label_tag('foo', CustomValue.new(:custom_field => field))
-    assert_select_in tag, 'label span[title]', 0
+    assert_select_in tag, 'label span[data-tooltip-text-value]', 0
   end
 
   def test_label_tag_should_include_for_attribute_for_select_tag

--- a/test/helpers/custom_fields_helper_test.rb
+++ b/test/helpers/custom_fields_helper_test.rb
@@ -32,13 +32,13 @@ class CustomFieldsHelperTest < Redmine::HelperTest
   def test_label_tag_should_include_description_as_stimulus_tooltip_if_present
     field = CustomField.new(:field_format => 'string', :description => 'This is the description')
     tag = custom_field_label_tag('foo', CustomValue.new(:custom_field => field))
-    assert_select_in tag, 'label span[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'This is the description'
+    assert_select_in tag, 'label span[data-tooltip-target=?][title=?]', 'trigger', 'This is the description'
   end
 
   def test_label_tag_should_not_include_tooltip_if_description_is_blank
     field = CustomField.new(:field_format => 'string')
     tag = custom_field_label_tag('foo', CustomValue.new(:custom_field => field))
-    assert_select_in tag, 'label span[data-tooltip-text-value]', 0
+    assert_select_in tag, 'label span[data-tooltip-target]', 0
   end
 
   def test_label_tag_should_include_for_attribute_for_select_tag

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -412,7 +412,7 @@ class IssuesHelperTest < Redmine::HelperTest
       " closed rel-follows\">",
       html
     )
-    assert_include 'title="Remove relation"', html
+    assert_include 'data-tooltip-text-value="Remove relation"', html
 
     html = render_issue_relations(closed_issue, [relation])
     assert_include(
@@ -424,7 +424,7 @@ class IssuesHelperTest < Redmine::HelperTest
       " rel-precedes\">",
       html
     )
-    assert_include 'title="Remove relation"', html
+    assert_include 'data-tooltip-text-value="Remove relation"', html
   end
 
   def test_render_descendants_stats

--- a/test/helpers/issues_helper_test.rb
+++ b/test/helpers/issues_helper_test.rb
@@ -412,7 +412,8 @@ class IssuesHelperTest < Redmine::HelperTest
       " closed rel-follows\">",
       html
     )
-    assert_include 'data-tooltip-text-value="Remove relation"', html
+    assert_include 'title="Remove relation"', html
+    assert_include 'data-tooltip-target="trigger"', html
 
     html = render_issue_relations(closed_issue, [relation])
     assert_include(
@@ -424,7 +425,8 @@ class IssuesHelperTest < Redmine::HelperTest
       " rel-precedes\">",
       html
     )
-    assert_include 'data-tooltip-text-value="Remove relation"', html
+    assert_include 'title="Remove relation"', html
+    assert_include 'data-tooltip-target="trigger"', html
   end
 
   def test_render_descendants_stats

--- a/test/helpers/journals_helper_test.rb
+++ b/test/helpers/journals_helper_test.rb
@@ -47,8 +47,8 @@ class JournalsHelperTest < Redmine::HelperTest
     journals = issue.visible_journals_with_index # add indice
     journal_actions = render_journal_actions(issue, journals.first, {reply_links: true})
 
-    assert_select_in journal_actions, 'a[title=?][class="icon-only icon-quote"]', 'Quote'
-    assert_select_in journal_actions, 'a[title=?][class="icon-only icon-edit"]', 'Edit'
+    assert_select_in journal_actions, 'a[data-controller=?][data-tooltip-text-value=?][class="icon-only icon-quote"]', 'tooltip', 'Quote'
+    assert_select_in journal_actions, 'a[data-controller=?][data-tooltip-text-value=?][class="icon-only icon-edit"]', 'tooltip', 'Edit'
     assert_select_in journal_actions, 'div[class="drdn-items"] a[class="icon icon-del"]'
     assert_select_in journal_actions, 'div[class="drdn-items"] a[class="icon icon-copy-link"]'
     assert_select_in journal_actions, 'span.reaction-button-wrapper'

--- a/test/helpers/journals_helper_test.rb
+++ b/test/helpers/journals_helper_test.rb
@@ -47,8 +47,8 @@ class JournalsHelperTest < Redmine::HelperTest
     journals = issue.visible_journals_with_index # add indice
     journal_actions = render_journal_actions(issue, journals.first, {reply_links: true})
 
-    assert_select_in journal_actions, 'a[data-controller=?][data-tooltip-text-value=?][class="icon-only icon-quote"]', 'tooltip', 'Quote'
-    assert_select_in journal_actions, 'a[data-controller=?][data-tooltip-text-value=?][class="icon-only icon-edit"]', 'tooltip', 'Edit'
+    assert_select_in journal_actions, 'a[data-tooltip-target=?][title=?][class="icon-only icon-quote"]', 'trigger', 'Quote'
+    assert_select_in journal_actions, 'a[data-tooltip-target=?][title=?][class="icon-only icon-edit"]', 'trigger', 'Edit'
     assert_select_in journal_actions, 'div[class="drdn-items"] a[class="icon icon-del"]'
     assert_select_in journal_actions, 'div[class="drdn-items"] a[class="icon icon-copy-link"]'
     assert_select_in journal_actions, 'span.reaction-button-wrapper'

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -26,12 +26,22 @@ class ProjectsHelperTest < Redmine::HelperTest
   def test_link_to_version_within_project
     @project = Project.find(2)
     User.current = User.find(1)
-    assert_equal '<a title="07/01/2006" href="/versions/5">Alpha</a>', link_to_version(Version.find(5))
+    assert_select_in link_to_version(Version.find(5)),
+                     'a[href=?][data-controller=?][data-tooltip-text-value=?]',
+                     '/versions/5',
+                     'tooltip',
+                     '07/01/2006',
+                     :text => 'Alpha'
   end
 
   def test_link_to_version
     User.current = User.find(1)
-    assert_equal '<a title="07/01/2006" href="/versions/5">OnlineStore - Alpha</a>', link_to_version(Version.find(5))
+    assert_select_in link_to_version(Version.find(5)),
+                     'a[href=?][data-controller=?][data-tooltip-text-value=?]',
+                     '/versions/5',
+                     'tooltip',
+                     '07/01/2006',
+                     :text => 'OnlineStore - Alpha'
   end
 
   def test_link_to_version_without_effective_date

--- a/test/helpers/projects_helper_test.rb
+++ b/test/helpers/projects_helper_test.rb
@@ -27,9 +27,9 @@ class ProjectsHelperTest < Redmine::HelperTest
     @project = Project.find(2)
     User.current = User.find(1)
     assert_select_in link_to_version(Version.find(5)),
-                     'a[href=?][data-controller=?][data-tooltip-text-value=?]',
+                     'a[href=?][data-tooltip-target=?][title=?]',
                      '/versions/5',
-                     'tooltip',
+                     'trigger',
                      '07/01/2006',
                      :text => 'Alpha'
   end
@@ -37,9 +37,9 @@ class ProjectsHelperTest < Redmine::HelperTest
   def test_link_to_version
     User.current = User.find(1)
     assert_select_in link_to_version(Version.find(5)),
-                     'a[href=?][data-controller=?][data-tooltip-text-value=?]',
+                     'a[href=?][data-tooltip-target=?][title=?]',
                      '/versions/5',
-                     'tooltip',
+                     'trigger',
                      '07/01/2006',
                      :text => 'OnlineStore - Alpha'
   end

--- a/test/helpers/reactions_helper_test.rb
+++ b/test/helpers/reactions_helper_test.rb
@@ -48,7 +48,7 @@ class ReactionsHelperTest < ActionView::TestCase
 
     result = reaction_button(journals(:journals_001))
 
-    assert_select_in result, 'span.reaction-button.readonly[title=?]', 'John Smith'
+    assert_select_in result, 'span.reaction-button.readonly[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
     assert_select_in result, 'a.reaction-button', false
   end
 
@@ -58,7 +58,7 @@ class ReactionsHelperTest < ActionView::TestCase
 
     result = reaction_button(issue6)
 
-    assert_select_in result, 'span.reaction-button.readonly[title=?]', 'John Smith'
+    assert_select_in result, 'span.reaction-button.readonly[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
     assert_select_in result, 'a.reaction-button', false
   end
 
@@ -83,7 +83,7 @@ class ReactionsHelperTest < ActionView::TestCase
     expected_tooltip = 'Bob9 Doe, Bob8 Doe, Bob7 Doe, Bob6 Doe, Bob5 Doe, ' \
                        'Bob4 Doe, Bob3 Doe, Bob2 Doe, Bob1 Doe, and Bob0 Doe'
 
-    assert_select_in result, 'a.reaction-button[title=?]', expected_tooltip
+    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', expected_tooltip
   end
 
   test 'reaction_button includes tooltip with 10 usernames and others count when reactions exceed 10' do
@@ -99,7 +99,7 @@ class ReactionsHelperTest < ActionView::TestCase
     expected_tooltip = 'Bob10 Doe, Bob9 Doe, Bob8 Doe, Bob7 Doe, Bob6 Doe, ' \
                        'Bob5 Doe, Bob4 Doe, Bob3 Doe, Bob2 Doe, Bob1 Doe, and 1 other'
 
-    assert_select_in result, 'a.reaction-button[title=?]', expected_tooltip
+    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', expected_tooltip
   end
 
   test 'reaction_button should be label less when no reactions' do
@@ -133,7 +133,7 @@ class ReactionsHelperTest < ActionView::TestCase
       reaction_button(issue2)
     end
 
-    assert_select_in result, 'a.reaction-button[title=?]', 'John Smith and Dave Lopper'
+    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith and Dave Lopper'
 
     # When all users are non-visible users
     issue2.reaction_detail = Reaction::Detail.new(
@@ -144,7 +144,7 @@ class ReactionsHelperTest < ActionView::TestCase
       reaction_button(issue2)
     end
 
-    assert_select_in result, 'a.reaction-button[title]', false
+    assert_select_in result, 'a.reaction-button[data-tooltip-text-value]', false
     assert_select_in result, 'a.reaction-button' do
       assert_select 'span.icon-label', false
     end
@@ -155,7 +155,7 @@ class ReactionsHelperTest < ActionView::TestCase
       reaction_button(issues(:issues_001))
     end
 
-    assert_select_in result, 'a.reaction-button[title=?]', 'Dave Lopper、John Smith、Redmine Admin'
+    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Dave Lopper、John Smith、Redmine Admin'
   end
 
   test 'reaction_button for reacted object' do

--- a/test/helpers/reactions_helper_test.rb
+++ b/test/helpers/reactions_helper_test.rb
@@ -48,7 +48,7 @@ class ReactionsHelperTest < ActionView::TestCase
 
     result = reaction_button(journals(:journals_001))
 
-    assert_select_in result, 'span.reaction-button.readonly[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
+    assert_select_in result, 'span.reaction-button.readonly[data-tooltip-target=?][title=?]', 'trigger', 'John Smith'
     assert_select_in result, 'a.reaction-button', false
   end
 
@@ -58,7 +58,7 @@ class ReactionsHelperTest < ActionView::TestCase
 
     result = reaction_button(issue6)
 
-    assert_select_in result, 'span.reaction-button.readonly[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith'
+    assert_select_in result, 'span.reaction-button.readonly[data-tooltip-target=?][title=?]', 'trigger', 'John Smith'
     assert_select_in result, 'a.reaction-button', false
   end
 
@@ -83,7 +83,7 @@ class ReactionsHelperTest < ActionView::TestCase
     expected_tooltip = 'Bob9 Doe, Bob8 Doe, Bob7 Doe, Bob6 Doe, Bob5 Doe, ' \
                        'Bob4 Doe, Bob3 Doe, Bob2 Doe, Bob1 Doe, and Bob0 Doe'
 
-    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', expected_tooltip
+    assert_select_in result, 'a.reaction-button[data-tooltip-target=?][title=?]', 'trigger', expected_tooltip
   end
 
   test 'reaction_button includes tooltip with 10 usernames and others count when reactions exceed 10' do
@@ -99,7 +99,7 @@ class ReactionsHelperTest < ActionView::TestCase
     expected_tooltip = 'Bob10 Doe, Bob9 Doe, Bob8 Doe, Bob7 Doe, Bob6 Doe, ' \
                        'Bob5 Doe, Bob4 Doe, Bob3 Doe, Bob2 Doe, Bob1 Doe, and 1 other'
 
-    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', expected_tooltip
+    assert_select_in result, 'a.reaction-button[data-tooltip-target=?][title=?]', 'trigger', expected_tooltip
   end
 
   test 'reaction_button should be label less when no reactions' do
@@ -133,7 +133,7 @@ class ReactionsHelperTest < ActionView::TestCase
       reaction_button(issue2)
     end
 
-    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'John Smith and Dave Lopper'
+    assert_select_in result, 'a.reaction-button[data-tooltip-target=?][title=?]', 'trigger', 'John Smith and Dave Lopper'
 
     # When all users are non-visible users
     issue2.reaction_detail = Reaction::Detail.new(
@@ -144,7 +144,7 @@ class ReactionsHelperTest < ActionView::TestCase
       reaction_button(issue2)
     end
 
-    assert_select_in result, 'a.reaction-button[data-tooltip-text-value]', false
+    assert_select_in result, 'a.reaction-button[data-tooltip-target]', false
     assert_select_in result, 'a.reaction-button' do
       assert_select 'span.icon-label', false
     end
@@ -155,7 +155,7 @@ class ReactionsHelperTest < ActionView::TestCase
       reaction_button(issues(:issues_001))
     end
 
-    assert_select_in result, 'a.reaction-button[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Dave Lopper、John Smith、Redmine Admin'
+    assert_select_in result, 'a.reaction-button[data-tooltip-target=?][title=?]', 'trigger', 'Dave Lopper、John Smith、Redmine Admin'
   end
 
   test 'reaction_button for reacted object' do

--- a/test/helpers/watchers_helper_test.rb
+++ b/test/helpers/watchers_helper_test.rb
@@ -80,7 +80,7 @@ class WatchersHelperTest < Redmine::HelperTest
         assert_select 'li:nth-of-type(1)>a[href=?]', '/users/3', text: 'Dave Lopper'
         assert_select 'li:nth-of-type(2)>a[href=?]', '/users/2', text: 'John Smith'
         assert_select 'li:nth-of-type(3)>a[href=?]', '/users/1', text: 'Redmine Admin'
-        assert_select 'a.delete[title=?]', 'Remove', 3
+        assert_select 'a.delete[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Remove', 3
         assert_select 'a.delete.icon-link-break', 3
       end
     end
@@ -92,7 +92,7 @@ class WatchersHelperTest < Redmine::HelperTest
         assert_select 'li:nth-of-type(1)>a[href=?]', '/users/1', text: 'Admin Redmine'
         assert_select 'li:nth-of-type(2)>a[href=?]', '/users/3', text: 'Lopper Dave'
         assert_select 'li:nth-of-type(3)>a[href=?]', '/users/2', text: 'Smith John'
-        assert_select 'a.delete[title=?]', 'Remove', 3
+        assert_select 'a.delete[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Remove', 3
         assert_select 'a.delete.icon-link-break', 3
       end
     end

--- a/test/helpers/watchers_helper_test.rb
+++ b/test/helpers/watchers_helper_test.rb
@@ -80,7 +80,7 @@ class WatchersHelperTest < Redmine::HelperTest
         assert_select 'li:nth-of-type(1)>a[href=?]', '/users/3', text: 'Dave Lopper'
         assert_select 'li:nth-of-type(2)>a[href=?]', '/users/2', text: 'John Smith'
         assert_select 'li:nth-of-type(3)>a[href=?]', '/users/1', text: 'Redmine Admin'
-        assert_select 'a.delete[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Remove', 3
+        assert_select 'a.delete[data-tooltip-target=?][title=?]', 'trigger', 'Remove', 3
         assert_select 'a.delete.icon-link-break', 3
       end
     end
@@ -92,7 +92,7 @@ class WatchersHelperTest < Redmine::HelperTest
         assert_select 'li:nth-of-type(1)>a[href=?]', '/users/1', text: 'Admin Redmine'
         assert_select 'li:nth-of-type(2)>a[href=?]', '/users/3', text: 'Lopper Dave'
         assert_select 'li:nth-of-type(3)>a[href=?]', '/users/2', text: 'Smith John'
-        assert_select 'a.delete[data-controller=?][data-tooltip-text-value=?]', 'tooltip', 'Remove', 3
+        assert_select 'a.delete[data-tooltip-target=?][title=?]', 'trigger', 'Remove', 3
         assert_select 'a.delete.icon-link-break', 3
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -350,7 +350,7 @@ module Redmine
 
     def pre_wrapper(text)
       icon = sprite_icon('copy-pre-content', size: 18)
-      '<div class="pre-wrapper" data-controller="clipboard"><a class="copy-pre-content-link icon-only" title="Copy" data-action="clipboard#copyPre">' +
+      '<div class="pre-wrapper" data-controller="clipboard"><a class="copy-pre-content-link icon-only" data-controller="tooltip" data-action="clipboard#copyPre mouseenter->tooltip#show mouseleave->tooltip#hide" data-tooltip-text-value="Copy">' +
       icon + '</a>' +
       text +
       '</div>'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -350,7 +350,9 @@ module Redmine
 
     def pre_wrapper(text)
       icon = sprite_icon('copy-pre-content', size: 18)
-      '<div class="pre-wrapper" data-controller="clipboard"><a class="copy-pre-content-link icon-only" data-controller="tooltip" data-action="clipboard#copyPre mouseenter->tooltip#show mouseleave->tooltip#hide" data-tooltip-text-value="Copy">' +
+      '<div class="pre-wrapper" data-controller="clipboard">' +
+      '<a class="copy-pre-content-link icon-only" data-action="clipboard#copyPre" ' +
+      'data-tooltip-target="trigger" title="Copy">' +
       icon + '</a>' +
       text +
       '</div>'


### PR DESCRIPTION
## 目的

ツールチップを表示するコンポーネントを stimulus ベースに変更する。理由は、現在の jquery ベースでは、rails-ujs や今後導入を目指している turbo を使ってそれら自体が書き換えられた場合に、表示されたツールチップが消えない問題があるから。

## 方針

すでに https://www.redmine.org/issues/42517 でstimulusに置き換える実装案が提案されている。添付された実装はこれ https://www.redmine.org/attachments/34170

しかし、この実装には次の問題と改善点があると思っている

* cssのスタッキングコンテキストによりツールチップの一部が表示されない可能性がある
* stimulusの使い方としてはベストとは言えないと思う（どちらかというとjQuery的な実装に見える）。そのため、どのように実装されているか他の開発者が理解しづらい可能性がある
* title属性の内容をツールチップとして表示するのは非常に手軽だが、過剰なツールチップの表示にもつながる可能性があると思っている。title属性とツールチップは本質的に異なるものなので、ツールチップを表示するという意思を持って実装できる方が良い方向につながる気がしている

次の方針で検討する。

* ツールチップの対象に個別にコントローラーを割り当てる。disconnect() イベントでツールチップを正しくクリアすることで現状の課題を解決する
* スタッキングコンテキストの問題を回避するため、bodyの末尾にツールチップ用の要素を動的に生成して表示する。現在と同じ方式

## 実装

- Rewrite tooltip_controller.js to dynamically create tooltip elements appended to document.body instead of using CSS ::after pseudo-element
- Update CSS to use .tooltip-body class with position: absolute and high z-index to avoid overflow clipping issues
- Replace title attributes with data-tooltip-text-value across helpers and views for declarative tooltip behavior
- Inline unnecessary tooltip variables in views and helpers
- Remove jQuery UI tooltip and legacy tooltip JavaScript

## 相談・伝達事項

一方で懸念点もある

* 表示パフォーマンスへの影響
  * チケットのコメント一覧にもツールチップの表示があるが、もし、コメントが300個あると、300のコントローラを初期化しないといけない。それが表示のパフォーマンス（速度、クライアントのメモリ・CPU負荷）に影響するか
* 移行には多くの変更箇所が必要。これまではtitle属性をつけておけば勝手にツールチップが表示されるが、stimulusコントローラーの定義を個別に追加しなければならない
  * 直感的なrailsのヘルパーメソッドを用意するとともに、ヘルパーメソッドが使えない場合はstimulusのコントローラやvalueなどを設定する
  * どのように使うのかをstimulusコントローラーのコメントに記載しておく。data-controller="tooltip" data-tooltip-text-value="<ツールチップの内容>" 、という感じに

