### PR TITLE
Fix flaky issue list sort tests for spent hours columns

### DIFF
--- a/test/functional/issues_controller_test.rb
+++ b/test/functional/issues_controller_test.rb
@@ -1332,10 +1332,16 @@ class IssuesControllerTest < Redmine::ControllerTest
   end
 
   def test_index_sort_by_spent_hours
-    get(:index, :params => {:sort => 'spent_hours:desc'})
+    get(
+      :index,
+      :params => {
+        :sort => 'spent_hours:desc',
+        :c => ['subject', 'spent_hours']
+      }
+    )
     assert_response :success
-    hours = issues_in_list.map(&:spent_hours)
-    assert_equal hours.sort.reverse, hours
+    assert_select 'td.spent_hours'
+    assert_equal ['154:15', '1:00', '0:00', '0:00', '0:00', '0:00'], columns_values_in_list('spent_hours')
   end
 
   def test_index_sort_by_spent_hours_should_sort_by_visible_spent_hours
@@ -1364,10 +1370,16 @@ class IssuesControllerTest < Redmine::ControllerTest
   end
 
   def test_index_sort_by_total_spent_hours
-    get(:index, :params => {:sort => 'total_spent_hours:desc'})
+    get(
+      :index,
+      :params => {
+        :sort => 'total_spent_hours:desc',
+        :c => ['subject', 'total_spent_hours']
+      }
+    )
     assert_response :success
-    hours = issues_in_list.map(&:total_spent_hours)
-    assert_equal hours.sort.reverse, hours
+    assert_select 'td.total_spent_hours'
+    assert_equal ['154:15', '1:00', '0:00', '0:00', '0:00', '0:00'], columns_values_in_list('total_spent_hours')
   end
 
   def test_index_sort_by_total_estimated_hours


### PR DESCRIPTION
This patch fixes flaky failures in `IssuesControllerTest#test_index_sort_by_spent_hours` and `#test_index_sort_by_total_spent_hours`.

For example, the following failure occurred in a MySQL test job:

```text
Failure:
IssuesControllerTest#test_index_sort_by_total_spent_hours [test/functional/issues_controller_test.rb:1370]:
--- expected
+++ actual
@@ -1 +1 @@
-[154.25, 1.0, 0.0, 0.0, 0.0, 0.0]
+[0.0, 0.0, 0.0, 1.0, 0.0, 154.25]
```

I investigated the direct cause of the random failure, but could not identify a stable trigger due to its low reproducibility.

However, the investigation showed that the existing assertions did not evaluate the response in the most appropriate way for this test. The purpose of these tests is to verify that the issue list rendered by the controller response is sorted as expected when using `spent_hours` or `total_spent_hours`.

Previously, the tests obtained issue IDs from the response, then recalculated values from the model using `issues_in_list.map(&:spent_hours)` and `issues_in_list.map(&:total_spent_hours)`. This does not strictly verify the column values actually rendered in the response.

This patch explicitly includes the `spent_hours` and `total_spent_hours` columns in the issue list, and verifies the values rendered in the response directly.

Since the fixture data is fixed, the tests now compare the rendered values with the expected arrays instead of comparing them with `sort.reverse`. This checks that the expected values are rendered in the expected order.